### PR TITLE
Enable API server for non optimistic finality requests

### DIFF
--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -133,16 +133,26 @@ export default class VM {
   }
 
   cachedSocialGet(key, recursive, blockId, options) {
-    return this.cachedPromise(`get:${recursive}:${key}`, () =>
-      socialGet(this.near, key, recursive)
+    return this.cachedPromise(
+      `get:${recursive}:${key}:${blockId}:${JSON.stringify(options)}`,
+      () => socialGet(this.near, key, recursive, blockId, options)
     );
   }
 
-  cachedSocialKeys(key) {
-    return this.cachedPromise(`keys:${key}`, () =>
-      cachedViewCall(this.near, NearConfig.contractName, "keys", {
-        keys: [key],
-      })
+  cachedSocialKeys(key, blockId, options) {
+    return this.cachedPromise(
+      `keys:${key}:${blockId}:${JSON.stringify(options)}`,
+      () =>
+        cachedViewCall(
+          this.near,
+          NearConfig.contractName,
+          "keys",
+          {
+            keys: [key],
+            options,
+          },
+          blockId
+        )
     );
   }
 
@@ -351,12 +361,12 @@ export default class VM {
         if (args.length < 1) {
           throw new Error("Missing argument 'keys' for Social.getr");
         }
-        return this.cachedSocialGet(args[0], true);
+        return this.cachedSocialGet(args[0], true, args[1], args[2]);
       } else if (callee === "Social.get" || callee === "socialGet") {
         if (args.length < 1) {
           throw new Error("Missing argument 'keys' for Social.get");
         }
-        return this.cachedSocialGet(args[0], false);
+        return this.cachedSocialGet(args[0], false, args[1], args[2]);
       } else if (callee === "parseInt") {
         return parseInt(...args);
       } else if (callee === "parseFloat") {
@@ -367,7 +377,7 @@ export default class VM {
         if (args.length < 1) {
           throw new Error("Missing argument 'keys' for Social.keys");
         }
-        return this.cachedSocialKeys(args[0]);
+        return this.cachedSocialKeys(args[0], args[1], args[2]);
       } else if (callee === "JSON.stringify" || callee === "stringify") {
         if (args.length < 1) {
           throw new Error("Missing argument 'obj' for JSON.stringify");


### PR DESCRIPTION
API server is a dedicated RPC server for providing get/keys actions. The server is fast and should be used for fetching large queries that requires ton of iterations on the data. E.g.

```javascript
const data = Social.keys("*/profile", "final");
```

It also supports historical data fetches starting from block `75942519`.

In the future the APIs can be expanded to support more data operations, e.g. get edit history for a field.