### PR TITLE
Expose multiple keys for Social.get, Social.getr, Social.keys

### DIFF
--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -156,13 +156,14 @@ export const cachedFetch = async (url, options) =>
     }
   );
 
-export const socialGet = async (near, key, recursive, blockId, options) => {
+export const socialGet = async (near, keys, recursive, blockId, options) => {
   if (!near) {
     return null;
   }
-  key = recursive ? `${key}/**` : `${key}`;
+  keys = Array.isArray(keys) ? keys : [keys];
+  keys = keys.map((key) => (recursive ? `${key}/**` : `${key}`));
   const args = {
-    keys: [key],
+    keys,
     options,
   };
   let data = await cachedViewCall(
@@ -173,13 +174,15 @@ export const socialGet = async (near, key, recursive, blockId, options) => {
     blockId
   );
 
-  const parts = key.split("/");
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
-    if (part === "*" || part === "**") {
-      break;
+  if (keys.length === 1) {
+    const parts = keys[0].split("/");
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === "*" || part === "**") {
+        break;
+      }
+      data = data?.[part];
     }
-    data = data?.[part];
   }
 
   return data;

--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -11,6 +11,7 @@ import { sanitizeUrl } from "@braintree/sanitize-url";
 import { NearConfig } from "../data/near";
 import { isObject } from "url/util";
 import { Markdown } from "../components/Markdown";
+import { isAsync } from "@babel/core/lib/gensync-utils/async";
 
 const LoopLimit = 10000;
 const MaxDepth = 32;
@@ -860,23 +861,25 @@ export default class VM {
     return null;
   }
 
-  cachedSocialGet(key, recursive, blockId, options) {
+  cachedSocialGet(keys, recursive, blockId, options) {
+    keys = Array.isArray(keys) ? keys : [keys];
     return this.cachedPromise(
-      `get:${JSON.stringify({ key, recursive, blockId, options })}`,
-      () => socialGet(this.near, key, recursive, blockId, options)
+      `get:${JSON.stringify({ keys, recursive, blockId, options })}`,
+      () => socialGet(this.near, keys, recursive, blockId, options)
     );
   }
 
-  cachedSocialKeys(key, blockId, options) {
+  cachedSocialKeys(keys, blockId, options) {
+    keys = Array.isArray(keys) ? keys : [keys];
     return this.cachedPromise(
-      `keys:${JSON.stringify({ key, blockId, options })}`,
+      `keys:${JSON.stringify({ keys, blockId, options })}`,
       () =>
         cachedViewCall(
           this.near,
           NearConfig.contractName,
           "keys",
           {
-            keys: [key],
+            keys,
             options,
           },
           blockId


### PR DESCRIPTION
The first element now supports an array of strings (key patterns)

```
const value = Social.get(
  ["self.social.near/profile/**", "mob.near/profile/**"],
  "final"
);

const text = `
\`\`\`json
${JSON.stringify(value)}
\`\`\`
`;

return (
  <div>
    <Markdown text={text} />
  </div>
);
```