### PR TITLE
Function props

### DIFF
--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -728,7 +728,7 @@ class VmStack {
                 touches: arg?.touches,
               };
             }
-            v = JSON.parse(JSON.stringify(arg));
+            v = deepCopy(arg);
           } catch (e) {
             console.warn(e);
           }


### PR DESCRIPTION
- Refactor MemberExpression.
- Better error handling on function calls
- Don't JSONIFY props and state.

This enables ability to pass functions as props into other widgets. For example, implement a helper edit widgets like `ImageSelector` that takes the following props:
```jsx
{
  image: state.image,
  onChange: (image) => State.update({image}),
}
```

It should be able to call `onChange` and the root component should update.