### PR TITLE
Redesign editor to be full width

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -33,10 +33,3 @@ body, html {
 .outline-none {
   outline: 0 !important;
 }
-
-.code-editor {
-  height: 70vh;
-  //textarea, pre {
-  //  word-break: break-all !important;
-  //}
-}

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -245,7 +245,7 @@ export default function EditorPage(props) {
                 defaultLanguage="json"
                 onChange={(props) => setWidgetProps(props)}
                 wrapperProps={{
-                  onBlur: () => reformatProps(code),
+                  onBlur: () => reformatProps(widgetProps),
                 }}
               />
             </div>

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -18,6 +18,12 @@ const WidgetPropsKey = LsKey + "widgetProps:";
 
 const DefaultEditorCode = "return <div>Hello World</div>;";
 
+const Tab = {
+  Editor: "editor",
+  Props: "props",
+  Widget: "widget",
+};
+
 export default function EditorPage(props) {
   const { widgetSrc } = useParams();
   const history = useHistory();
@@ -34,6 +40,8 @@ export default function EditorPage(props) {
   const [propsError, setPropsError] = useState(null);
   const near = useNear();
   const accountId = near?.accountId;
+
+  const [tab, setTab] = useState(Tab.Editor);
 
   useEffect(() => {
     setWidgetSrc({
@@ -117,12 +125,62 @@ export default function EditorPage(props) {
     [updateCode]
   );
 
+  const reformatProps = useCallback(
+    (props) => {
+      try {
+        const formattedProps = JSON.stringify(JSON.parse(props), null, 2);
+        setWidgetProps(formattedProps);
+      } catch (e) {
+        console.log(e);
+      }
+    },
+    [setWidgetProps]
+  );
+
   return (
     <div>
       <div className="container">
-        <div className="row mb-3 min-vh-100">
-          <div className="col-md-6">
-            <h5>Editor</h5>
+        <div className="min-vh-100">
+          <ul className="nav nav-tabs mb-2">
+            <li className="nav-item">
+              <button
+                className={`nav-link ${tab === Tab.Editor ? "active" : ""}`}
+                aria-current="page"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setTab(Tab.Editor);
+                }}
+              >
+                Editor
+              </button>
+            </li>
+            <li className="nav-item">
+              <button
+                className={`nav-link ${tab === Tab.Props ? "active" : ""}`}
+                aria-current="page"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setTab(Tab.Props);
+                }}
+              >
+                Props
+              </button>
+            </li>
+            <li className="nav-item">
+              <button
+                className={`nav-link ${tab === Tab.Widget ? "active" : ""}`}
+                aria-current="page"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setRenderCode(code);
+                  setTab(Tab.Widget);
+                }}
+              >
+                Widget Preview
+              </button>
+            </li>
+          </ul>
+          <div className={`${tab === Tab.Editor ? "" : "visually-hidden"}`}>
             <div className="input-group mb-3">
               <span className="input-group-text" id="widget-path-prefix">
                 {accountId}/widget/
@@ -137,7 +195,7 @@ export default function EditorPage(props) {
                 onChange={(e) => updateWidgetName(e.target.value)}
               />
             </div>
-            <div className="form-control mb-3 code-editor">
+            <div className="form-control mb-3" style={{ height: "70vh" }}>
               <Editor
                 value={code}
                 defaultLanguage="javascript"
@@ -182,21 +240,24 @@ export default function EditorPage(props) {
                 </a>
               )}
             </div>
-            <div className="mb-3">
-              Props for debugging (JSON)
-              <textarea
-                className="form-control font-monospace mb-3"
-                value={widgetProps}
-                rows={5}
-                onChange={(e) => setWidgetProps(e.target.value)}
-              />
-              {propsError && (
-                <pre className="alert alert-danger">{propsError}</pre>
-              )}
-            </div>
           </div>
-          <div className="col-md-6 mb-3">
-            <h5>Widget</h5>
+          <div className={`${tab === Tab.Props ? "" : "visually-hidden"}`}>
+            Props for debugging (JSON)
+            <div className="form-control mb-3" style={{ height: "40vh" }}>
+              <Editor
+                value={widgetProps}
+                defaultLanguage="json"
+                onChange={(props) => setWidgetProps(props)}
+                wrapperProps={{
+                  onBlur: () => reformatProps(code),
+                }}
+              />
+            </div>
+            {propsError && (
+              <pre className="alert alert-danger">{propsError}</pre>
+            )}
+          </div>
+          <div className={`${tab === Tab.Widget ? "" : "visually-hidden"}`}>
             <div className="container">
               <div className="row">
                 <div className="d-inline-block position-relative overflow-hidden">

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -146,10 +146,7 @@ export default function EditorPage(props) {
               <button
                 className={`nav-link ${tab === Tab.Editor ? "active" : ""}`}
                 aria-current="page"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setTab(Tab.Editor);
-                }}
+                onClick={() => setTab(Tab.Editor)}
               >
                 Editor
               </button>
@@ -158,10 +155,7 @@ export default function EditorPage(props) {
               <button
                 className={`nav-link ${tab === Tab.Props ? "active" : ""}`}
                 aria-current="page"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setTab(Tab.Props);
-                }}
+                onClick={() => setTab(Tab.Props)}
               >
                 Props
               </button>
@@ -170,8 +164,7 @@ export default function EditorPage(props) {
               <button
                 className={`nav-link ${tab === Tab.Widget ? "active" : ""}`}
                 aria-current="page"
-                onClick={(e) => {
-                  e.preventDefault();
+                onClick={() => {
                   setRenderCode(code);
                   setTab(Tab.Widget);
                 }}
@@ -208,7 +201,10 @@ export default function EditorPage(props) {
             <div className="mb-3">
               <button
                 className="btn btn-success"
-                onClick={() => setRenderCode(code)}
+                onClick={() => {
+                  setRenderCode(code);
+                  setTab(Tab.Widget);
+                }}
               >
                 Render preview
               </button>


### PR DESCRIPTION
- Use Tabs for editor, props and the preview.
- Monaco editor for JSON on props.
- Auto-render on switch to preview