### PR TITLE
Cache invalidation

### DIFF
--- a/src/components/Commit.js
+++ b/src/components/Commit.js
@@ -9,6 +9,7 @@ import Modal from "react-bootstrap/Modal";
 import { Markdown } from "./Markdown";
 import { StorageCostPerByte } from "../data/near";
 import { ToggleButton, ToggleButtonGroup } from "react-bootstrap";
+import { invalidateCache } from "../data/cache";
 
 const jsonMarkdown = (data) => {
   const json = JSON.stringify(data, null, 2);
@@ -196,8 +197,13 @@ export const CommitButton = (props) => {
           }
           setLoading(false);
           if (onCommit) {
-            onCommit(commit.data);
+            try {
+              onCommit(commit.data);
+            } catch (e) {
+              console.error(e);
+            }
           }
+          invalidateCache(commit.data);
         }}
       />
     </>

--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -94,20 +94,19 @@ export function Widget(props) {
       return;
     }
     setState(undefined);
-    setVm((prev) => {
-      if (prev) {
-        prev.alive = false;
-      }
-      return new VM(
-        near,
-        gkey,
-        parsedCode,
-        setState,
-        setCache,
-        confirmTransaction,
-        depth
-      );
-    });
+    const vm = new VM(
+      near,
+      gkey,
+      parsedCode,
+      setState,
+      setCache,
+      confirmTransaction,
+      depth
+    );
+    setVm(vm);
+    return () => {
+      vm.alive = false;
+    };
   }, [near, gkey, parsedCode, depth]);
 
   useEffect(() => {

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -231,3 +231,47 @@ export const convertToStringLeaves = (data) => {
       }, {})
     : stringify(data);
 };
+
+const matchGet = (obj, keys) => {
+  const matchKey = keys[0];
+  let isRecursiveMatch = matchKey === "**";
+  if (isRecursiveMatch) {
+    return keys.length === 1;
+  }
+  const values =
+    matchKey === "*" || isRecursiveMatch
+      ? Object.values(obj)
+      : matchKey in obj
+      ? [obj[matchKey]]
+      : [];
+
+  return values.some((value) =>
+    isObject(value)
+      ? keys.length > 1
+        ? matchGet(value, keys.slice(1))
+        : value[""] !== undefined
+      : keys.length === 1
+  );
+};
+
+const matchKeys = (obj, keys) => {
+  const matchKey = keys[0];
+  const values =
+    matchKey === "*"
+      ? Object.values(obj)
+      : matchKey in obj
+      ? [obj[matchKey]]
+      : [];
+
+  return values.some(
+    (value) =>
+      keys.length === 1 || (isObject(value) && matchKeys(value, keys.slice(1)))
+  );
+};
+
+export const patternMatch = (method, pattern, data) => {
+  const path = pattern.split("/");
+  return method === "get"
+    ? matchGet(data, path)
+    : method === "keys" && matchKeys(data, path);
+};


### PR DESCRIPTION
A successful commit action will trigger automatic cache invalidation for affected widgets. Those widgets will refetch the data and re-render. 