### PR TITLE
Save fetched data to local DB. Refresh when new value is fetched

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bootstrap-icons": "^1.9.0",
     "collections": "^5.1.12",
     "error-polyfill": "^0.1.2",
+    "idb": "^7.1.1",
     "local-storage": "^2.0.0",
     "near-api-js": "^0.45.1",
     "prettier": "^2.7.1",

--- a/src/App.js
+++ b/src/App.js
@@ -49,9 +49,11 @@ function App(props) {
     if (!near) {
       return;
     }
-    setWalletModal(
-      setupModal(near.selector, { contractId: NearConfig.contractName })
-    );
+    near.selector.then((selector) => {
+      setWalletModal(
+        setupModal(selector, { contractId: NearConfig.contractName })
+      );
+    });
   }, [near]);
 
   const requestSignIn = useCallback(

--- a/src/components/Commit.js
+++ b/src/components/Commit.js
@@ -7,9 +7,9 @@ import {
 import { displayNear, Loading } from "../data/utils";
 import Modal from "react-bootstrap/Modal";
 import { Markdown } from "./Markdown";
-import { StorageCostPerByte } from "../data/near";
+import { StorageCostPerByte, useAccountId, useNear } from "../data/near";
 import { ToggleButton, ToggleButtonGroup } from "react-bootstrap";
-import { invalidateCache } from "../data/cache";
+import { useCache } from "../data/cache";
 
 const jsonMarkdown = (data) => {
   const json = JSON.stringify(data, null, 2);
@@ -129,15 +129,17 @@ export const Commit = (props) => {
 };
 
 export const CommitButton = (props) => {
+  const near = useNear();
+  const accountId = useAccountId();
+  const cache = useCache();
+
   const data = props.data;
-  const near = props.near;
   const children = props.children;
   const originalOnClick = props.onClick;
   const onCommit = props.onCommit;
   const disabled = props.disabled;
   const filteredProps = Object.assign({}, props);
   delete filteredProps.data;
-  delete filteredProps.near;
   delete filteredProps.onClick;
   delete filteredProps.children;
   delete filteredProps.onCommit;
@@ -153,7 +155,7 @@ export const CommitButton = (props) => {
     if (!loading) {
       return;
     }
-    if (!near.accountId) {
+    if (!accountId) {
       return;
     }
     if (JSON.stringify(data ?? null) === JSON.stringify(lastData ?? null)) {
@@ -164,7 +166,7 @@ export const CommitButton = (props) => {
     prepareCommit(near, data, forceRewrite).then((newCommit) => {
       setCommit(newCommit);
     });
-  }, [loading, data, lastData, forceRewrite, near]);
+  }, [loading, data, lastData, forceRewrite, near, accountId]);
 
   return (
     <>
@@ -203,7 +205,7 @@ export const CommitButton = (props) => {
               console.error(e);
             }
           }
-          invalidateCache(commit.data);
+          cache.invalidateCache(commit.data);
         }}
       />
     </>

--- a/src/components/ConfirmTransaction.js
+++ b/src/components/ConfirmTransaction.js
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from "react";
 import Modal from "react-bootstrap/Modal";
 import { Markdown } from "./Markdown";
 import { Loading } from "../data/utils";
+import { useNear } from "../data/near";
 
 const jsonMarkdown = (data) => {
   const json = JSON.stringify(data, null, 2);
@@ -11,12 +12,12 @@ ${json}
 };
 
 export default function ConfirmTransaction(props) {
+  const near = useNear();
   const [loading, setLoading] = useState(false);
 
   const onHide = props.onHide;
   const transaction = props.transaction;
   const show = !!transaction;
-  const near = props.near;
 
   const onConfirm = useCallback(async () => {
     const res = await near.functionCall(

--- a/src/data/cache.js
+++ b/src/data/cache.js
@@ -1,5 +1,7 @@
 import { NearConfig } from "./near";
 import { patternMatch } from "./utils";
+import { openDB } from "idb";
+import { singletonHook } from "react-singleton-hook";
 
 const Action = {
   ViewCall: "ViewCall",
@@ -7,175 +9,227 @@ const Action = {
   Block: "Block",
 };
 
-const globalCache = {};
-const invalidationCallbacks = {};
-
-const cachedPromise = async (key, promise, onInvalidate) => {
-  key = JSON.stringify(key);
-  if (onInvalidate) {
-    invalidationCallbacks[key] = invalidationCallbacks[key] || [];
-    invalidationCallbacks[key].push(onInvalidate);
-  }
-  if (key in globalCache) {
-    return await globalCache[key];
-  }
-  return await (globalCache[key] = promise());
+const CacheStatus = {
+  NotStarted: "NotStarted",
+  InProgress: "InProgress",
+  Done: "Done",
 };
 
-export const invalidateCache = (data) => {
-  const affectedKeys = [];
-  Object.keys(globalCache).forEach((stringKey) => {
-    let key;
-    try {
-      key = JSON.parse(stringKey);
-    } catch (e) {
-      console.error("Key deserialization failed", stringKey);
-      return;
+const CacheDebug = false;
+
+function invalidateCallbacks(cached, isFinal) {
+  if (cached.invalidationCallbacks?.length) {
+    const callbacks = cached.invalidationCallbacks;
+    cached.invalidationCallbacks = [];
+    setTimeout(
+      () => {
+        callbacks.forEach((cb) => {
+          try {
+            cb();
+          } catch {
+            // ignore
+          }
+        });
+      },
+      isFinal ? NearConfig.finalSynchronizationDelayMs + 50 : 50
+    );
+  }
+}
+
+const CacheDb = "cacheDb";
+const CacheDbObject = "cache-v1";
+
+class Cache {
+  constructor() {
+    this.dbPromise = openDB(CacheDb, 1, {
+      upgrade(db) {
+        db.createObjectStore(CacheDbObject);
+      },
+    });
+    this.cache = {};
+  }
+
+  async innerGet(key) {
+    return (await this.dbPromise).get(CacheDbObject, key);
+  }
+  async innerSet(key, val) {
+    return (await this.dbPromise).put(CacheDbObject, val, key);
+  }
+
+  cachedPromise(key, promise, onInvalidate) {
+    key = JSON.stringify(key);
+    const cached = this.cache[key] || {
+      status: CacheStatus.NotStarted,
+      invalidationCallbacks: [],
+      result: null,
+    };
+    this.cache[key] = cached;
+    if (onInvalidate) {
+      cached.invalidationCallbacks.push(onInvalidate);
     }
-    if (
-      key.action === Action.ViewCall &&
-      key.contractId === NearConfig.contractName &&
-      (!key.blockId || key.blockId === "optimistic" || key.blockId === "final")
-    ) {
-      try {
-        const keys = key.args?.keys;
-        if (
-          keys.some((pattern) => patternMatch(key.methodName, pattern, data))
-        ) {
-          affectedKeys.push([stringKey, key.blockId === "final"]);
-        }
-      } catch {
-        // ignore
+    if (cached.status !== CacheStatus.NotStarted) {
+      return cached.result;
+    }
+    cached.status = CacheStatus.InProgress;
+    this.innerGet(key).then((cachedResult) => {
+      if (cachedResult && cached.status === CacheStatus.InProgress) {
+        CacheDebug && console.log("Cached value", key, cachedResult);
+        cached.result = cachedResult;
+        cached.status = CacheStatus.InProgress;
+        invalidateCallbacks(cached, false);
       }
-    }
-  });
-  console.log("Cache invalidation", affectedKeys);
-  affectedKeys.forEach(([stringKey, isFinal]) => {
-    delete globalCache[stringKey];
-    const callbacks = invalidationCallbacks[stringKey];
-    delete invalidationCallbacks[stringKey];
-    if (callbacks) {
-      setTimeout(
-        () => {
-          callbacks.forEach((cb) => {
-            try {
-              cb();
-            } catch {
-              // ignore
-            }
-          });
-        },
-        isFinal ? NearConfig.finalSynchronizationDelayMs + 50 : 50
-      );
-    }
-  });
-};
-
-export const cachedBlock = async (near, blockId, onInvalidate) =>
-  cachedPromise(
-    {
-      action: Action.Block,
-      blockId,
-    },
-    () => near.block(blockId),
-    onInvalidate
-  );
-
-export const cachedViewCall = async (
-  near,
-  contractId,
-  methodName,
-  args,
-  blockId,
-  onInvalidate
-) =>
-  cachedPromise(
-    {
-      action: Action.ViewCall,
-      contractId,
-      methodName,
-      args,
-      blockId,
-    },
-    () => near.viewCall(contractId, methodName, args, blockId),
-    onInvalidate
-  );
-
-export const cachedFetch = async (url, options, onInvalidate) =>
-  cachedPromise(
-    {
-      action: Action.Fetch,
-      url,
-      options,
-    },
-    async () => {
-      options = {
-        method: options?.method,
-        headers: options?.headers,
-        body: options?.body,
-      };
-      try {
-        const response = await fetch(url, options);
-        const status = response.status;
-        const ok = response.ok;
-        const contentType = response.headers.get("content-type");
-        const body = await (ok &&
-        contentType &&
-        contentType.indexOf("application/json") !== -1
-          ? response.json()
-          : response.text());
-        return {
-          ok,
-          status,
-          contentType,
-          body,
-        };
-      } catch (e) {
-        return {
-          ok: false,
-          error: e.message,
-        };
+    });
+    promise().then((result) => {
+      CacheDebug && console.log("Fetched result", key);
+      cached.status = CacheStatus.Done;
+      if (JSON.stringify(result) !== JSON.stringify(cached.result)) {
+        cached.result = result;
+        this.innerSet(key, result);
+        CacheDebug && console.log("Replacing value", key, result);
+        invalidateCallbacks(cached, false);
       }
-    },
-    onInvalidate
-  );
-
-export const socialGet = async (
-  near,
-  keys,
-  recursive,
-  blockId,
-  options,
-  onInvalidate
-) => {
-  if (!near) {
+    });
+    CacheDebug && console.log("New cache request", key);
     return null;
   }
-  keys = Array.isArray(keys) ? keys : [keys];
-  keys = keys.map((key) => (recursive ? `${key}/**` : `${key}`));
-  const args = {
-    keys,
-    options,
-  };
-  let data = await cachedViewCall(
-    near,
-    NearConfig.contractName,
-    "get",
-    args,
-    blockId,
-    onInvalidate
-  );
 
-  if (keys.length === 1) {
-    const parts = keys[0].split("/");
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      if (part === "*" || part === "**") {
-        break;
+  invalidateCache(data) {
+    const affectedKeys = [];
+    Object.keys(this.cache).forEach((stringKey) => {
+      let key;
+      try {
+        key = JSON.parse(stringKey);
+      } catch (e) {
+        console.error("Key deserialization failed", stringKey);
+        return;
       }
-      data = data?.[part];
-    }
+      if (
+        key.action === Action.ViewCall &&
+        key.contractId === NearConfig.contractName &&
+        (!key.blockId ||
+          key.blockId === "optimistic" ||
+          key.blockId === "final")
+      ) {
+        try {
+          const keys = key.args?.keys;
+          if (
+            keys.some((pattern) => patternMatch(key.methodName, pattern, data))
+          ) {
+            affectedKeys.push([stringKey, key.blockId === "final"]);
+          }
+        } catch {
+          // ignore
+        }
+      }
+    });
+    console.log("Cache invalidation", affectedKeys);
+    affectedKeys.forEach(([stringKey, isFinal]) => {
+      const cached = this.cache[stringKey];
+      cached.status = CacheStatus.NotStarted;
+      invalidateCallbacks(cached, isFinal);
+    });
   }
 
-  return data;
-};
+  cachedBlock(near, blockId, onInvalidate) {
+    return this.cachedPromise(
+      {
+        action: Action.Block,
+        blockId,
+      },
+      () => near.block(blockId),
+      onInvalidate
+    );
+  }
+
+  cachedViewCall(near, contractId, methodName, args, blockId, onInvalidate) {
+    return this.cachedPromise(
+      {
+        action: Action.ViewCall,
+        contractId,
+        methodName,
+        args,
+        blockId,
+      },
+      () => near.viewCall(contractId, methodName, args, blockId),
+      onInvalidate
+    );
+  }
+
+  cachedFetch(url, options, onInvalidate) {
+    return this.cachedPromise(
+      {
+        action: Action.Fetch,
+        url,
+        options,
+      },
+      async () => {
+        options = {
+          method: options?.method,
+          headers: options?.headers,
+          body: options?.body,
+        };
+        try {
+          const response = await fetch(url, options);
+          const status = response.status;
+          const ok = response.ok;
+          const contentType = response.headers.get("content-type");
+          const body = await (ok &&
+          contentType &&
+          contentType.indexOf("application/json") !== -1
+            ? response.json()
+            : response.text());
+          return {
+            ok,
+            status,
+            contentType,
+            body,
+          };
+        } catch (e) {
+          return {
+            ok: false,
+            error: e.message,
+          };
+        }
+      },
+      onInvalidate
+    );
+  }
+
+  socialGet(near, keys, recursive, blockId, options, onInvalidate) {
+    if (!near) {
+      return null;
+    }
+    keys = Array.isArray(keys) ? keys : [keys];
+    keys = keys.map((key) => (recursive ? `${key}/**` : `${key}`));
+    const args = {
+      keys,
+      options,
+    };
+    let data = this.cachedViewCall(
+      near,
+      NearConfig.contractName,
+      "get",
+      args,
+      blockId,
+      onInvalidate
+    );
+
+    if (keys.length === 1) {
+      const parts = keys[0].split("/");
+      for (let i = 0; i < parts.length; i++) {
+        const part = parts[i];
+        if (part === "*" || part === "**") {
+          break;
+        }
+        data = data?.[part];
+      }
+    }
+
+    return data;
+  }
+}
+
+const defaultCache = new Cache();
+export const useCache = singletonHook(defaultCache, () => {
+  return defaultCache;
+});

--- a/src/data/cache.js
+++ b/src/data/cache.js
@@ -213,6 +213,9 @@ class Cache {
       blockId,
       onInvalidate
     );
+    if (data === null) {
+      return null;
+    }
 
     if (keys.length === 1) {
       const parts = keys[0].split("/");

--- a/src/data/commitData.js
+++ b/src/data/commitData.js
@@ -89,7 +89,7 @@ export const asyncCommitData = async (near, originalData, forceRewrite) => {
 };
 
 export const requestPermissionAndCommit = async (near, data, deposit) => {
-  const wallet = await near.selector.wallet();
+  const wallet = await (await near.selector).wallet();
   return await wallet.signAndSendTransaction({
     receiverId: NearConfig.contractName,
     actions: [

--- a/src/data/near.js
+++ b/src/data/near.js
@@ -108,7 +108,7 @@ async function functionCall(
   deposit
 ) {
   try {
-    const wallet = await near.selector.wallet();
+    const wallet = await (await near.selector).wallet();
     return await wallet.signAndSendTransaction({
       receiverId: contractName,
       actions: [
@@ -227,7 +227,7 @@ async function updateAccount(near, walletState) {
 
 async function _initNear() {
   const keyStore = new nearAPI.keyStores.BrowserLocalStorageKeyStore();
-  const selector = await setupWalletSelector({
+  const selector = setupWalletSelector({
     network: IsMainnet ? "mainnet" : "testnet",
     modules: [
       setupNearWallet(),
@@ -241,6 +241,7 @@ async function _initNear() {
   const nearConnection = await nearAPI.connect(
     Object.assign({ deps: { keyStore } }, NearConfig)
   );
+
   const _near = {};
   _near.selector = selector;
 
@@ -323,8 +324,7 @@ async function _initNear() {
     ],
   });
 
-  await updateAccount(_near, selector.store.getState());
-
+  // updateAccount(_near, selector.store.getState());
   return _near;
 }
 
@@ -354,10 +354,12 @@ export const useAccountId = singletonHook(defaultAccountId, () => {
     if (!near) {
       return;
     }
-    near.selector.store.observable.subscribe(async (walletState) => {
-      await updateAccount(near, walletState);
+    near.selector.then((selector) => {
+      selector.store.observable.subscribe(async (walletState) => {
+        await updateAccount(near, walletState);
 
-      setAccountId(near.accountId);
+        setAccountId(near.accountId);
+      });
     });
   }, [near]);
 

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -6,7 +6,7 @@ import prettier from "prettier";
 import parserBabel from "prettier/parser-babel";
 import { useHistory, useParams } from "react-router-dom";
 import Editor from "@monaco-editor/react";
-import { socialGet, useCache } from "../data/cache";
+import { useCache } from "../data/cache";
 import { CommitButton } from "../components/Commit";
 
 const EditorCodeKey = LsKey + "editorCode:";

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Widget } from "../components/Widget/Widget";
 import ls from "local-storage";
-import { LsKey, NearConfig, useNear } from "../data/near";
+import { LsKey, NearConfig, useAccountId, useNear } from "../data/near";
 import prettier from "prettier";
 import parserBabel from "prettier/parser-babel";
 import { useHistory, useParams } from "react-router-dom";
 import Editor from "@monaco-editor/react";
-import { socialGet } from "../data/cache";
+import { socialGet, useCache } from "../data/cache";
 import { CommitButton } from "../components/Commit";
 
 const EditorCodeKey = LsKey + "editorCode:";
@@ -45,7 +45,8 @@ export default function EditorPage(props) {
   const [propsError, setPropsError] = useState(null);
   const [metadata, setMetadata] = useState(undefined);
   const near = useNear();
-  const accountId = near?.accountId;
+  const cache = useCache();
+  const accountId = useAccountId();
 
   const [tab, setTab] = useState(Tab.Editor);
   const [layout, setLayoutState] = useState(
@@ -112,7 +113,15 @@ export default function EditorPage(props) {
           updateCode(DefaultEditorCode);
           setRenderCode(DefaultEditorCode);
         } else {
-          socialGet(near, widgetSrc).then((code) => {
+          const c = () => {
+            const code = cache.socialGet(
+              near,
+              widgetSrc,
+              false,
+              undefined,
+              undefined,
+              c
+            );
             if (code) {
               const widgetName = widgetSrc.split("/").slice(2).join("/");
               ls.set(WidgetNameKey, widgetName);
@@ -120,12 +129,14 @@ export default function EditorPage(props) {
               updateCode(code);
               setRenderCode(code);
             }
-          });
+          };
+
+          c();
         }
       }
       setWidgetPath(widgetSrc);
     }
-  }, [near, widgetSrc, updateCode]);
+  }, [near, cache, widgetSrc, updateCode]);
 
   const reformat = useCallback(
     (code) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3911,6 +3911,11 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
+idb@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.1.tgz#d910ded866d32c7ced9befc5bfdf36f572ced72b"
+  integrity sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==
+
 ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
With this cache rework, the page loads much faster, because old values are stored in the cache. This may lead to potential issues if the newly fetched value returns invalid value or fails. The old value maybe not refreshed.

Widgets may use the first available value, which can be non recent. This may result in strange results.

- Rework how fetching works to be fully sync.
- All cached calls require to provide `onInvalidate` callback.
- Move `selector` to async to speed up page load.
