### PR TITLE
Add account loading to context

### DIFF
--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -132,6 +132,7 @@ export function Widget(props) {
       return;
     }
     setContext({
+      loading: accountId === undefined,
       accountId,
     });
   }, [near, accountId]);

--- a/src/data/near.js
+++ b/src/data/near.js
@@ -207,7 +207,7 @@ async function updateAccount(near, walletState) {
     near.connectedContractId = null;
     walletState = selector.store.getState();
   }
-  near.accountId = walletState?.accounts?.[0]?.accountId;
+  near.accountId = walletState?.accounts?.[0]?.accountId ?? null;
   if (near.accountId) {
     near.publicKey = nearAPI.KeyPair.fromString(
       ls.get(
@@ -324,7 +324,6 @@ async function _initNear() {
     ],
   });
 
-  // updateAccount(_near, selector.store.getState());
   return _near;
 }
 
@@ -345,7 +344,7 @@ export const useNear = singletonHook(defaultNear, () => {
   return near;
 });
 
-const defaultAccountId = null;
+const defaultAccountId = undefined;
 export const useAccountId = singletonHook(defaultAccountId, () => {
   const [accountId, setAccountId] = useState(defaultAccountId);
   const near = useNear();


### PR DESCRIPTION
Added `context.loading` for the duration while wallet-selector is loading account data from chain. 

```jsx
const accountId = context.accountId;

if (context.loading) {
  return "Loading";
}

if (!accountId) {
  return "Please sign in with NEAR wallet to use this widget";
}

return `Hello, ${accountId}!`;
```