### PR TITLE
Add Storage object

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import { setupModal } from "@near-wallet-selector/modal-ui";
 import Big from "big.js";
 import EmbedPage from "./pages/EmbedPage";
 import Logo from "./images/near_social_combo.svg";
+import { Widget } from "./components/Widget/Widget";
 
 export const refreshAllowanceObj = {};
 

--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -109,23 +109,24 @@ export function Widget(props) {
       return;
     }
     setState(undefined);
-    const vm = new VM(
+    const vm = new VM({
       near,
       gkey,
-      parsedCode.parsedCode,
-      setState,
+      code: parsedCode.parsedCode,
+      setReactState: setState,
       cache,
-      () => {
+      refreshCache: () => {
         setCacheNonce((cacheNonce) => cacheNonce + 1);
       },
       confirmTransaction,
-      depth
-    );
+      depth,
+      widgetSrc: src,
+    });
     setVm(vm);
     return () => {
       vm.alive = false;
     };
-  }, [near, gkey, parsedCode, depth]);
+  }, [src, near, gkey, parsedCode, depth]);
 
   useEffect(() => {
     if (!near) {


### PR DESCRIPTION
Add `Storage` object to store data for widgets that is persistent across refreshes. Simulates localStorage access. It has 4 methods:

- `Storage.set(key, value)` - sets the public value for a given key under the current widget. The value will be public, so other widgets can read it.
- `Storage.get(key, widgetSrc?)` - returns the public value for a given key under the given widgetSrc or the current widget (if `widgetSrc` is omitted). Can only read public values.
- `Storage.privateSet(key, value)` - sets the private value for a given key under the current widget. The value is private, only the current widget can read it. Private and public values can share the same key and don't conflict.
- `Storage.privateGet(key)` - returns the private value for a given key under the current widget.

```jsx
const notificationFeedSrc = "mob.near/widget/NotificationFeed";

// Simplified for the example
const render = (counter, disabled) => counter;

const accountId = context.accountId;

if (context.loading || !accountId) {
  return render(0, true);
}

const lastBlockHeight = Storage.get("lastBlockHeight", notificationFeedSrc);
if (lastBlockHeight === null) {
  return render(0, true);
}

const notifications = Social.index("notify", accountId, {
  order: "asc",
  from: (lastBlockHeight ?? 0) + 1,
});
return render(notifications.length, false);
```

NotificationFeed widget:
```jsx
const accountId = context.accountId;

if (context.loading) {
  return "Loading";
}

if (!accountId) {
  return "Sign in with NEAR Wallet";
}

const notifications = Social.index("notify", accountId, {
  order: "desc",
});

if (notifications === null) {
  return "Loading";
}

if (notifications.length === 0) {
  return "No notifications";
}

Storage.set("lastBlockHeight", notifications[0].blockHeight);

return notifications;
```