### PR TITLE
Add async methods that return promises

### DIFF
--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -493,6 +493,13 @@ class VmStack {
           );
         }
         return this.vm.cachedNearView(...args);
+      } else if (keyword === "Near" && callee === "asyncView") {
+        if (args.length < 2) {
+          throw new Error(
+            "Method: Near.asyncView. Required arguments: 'contractName', 'methodName'. Optional: 'args', 'blockId/finality'"
+          );
+        }
+        return this.vm.asyncNearView(...args);
       } else if (keyword === "Near" && callee === "block") {
         return this.vm.cachedNearBlock(...args);
       } else if (keyword === "Near" && callee === "call") {
@@ -516,6 +523,13 @@ class VmStack {
           );
         }
         return this.vm.cachedFetch(...args);
+      } else if (callee === "asyncFetch") {
+        if (args.length < 1) {
+          throw new Error(
+            "Method: asyncFetch. Required arguments: 'url'. Optional: 'options'"
+          );
+        }
+        return this.vm.asyncFetch(...args);
       } else if (callee === "parseInt") {
         return parseInt(...args);
       } else if (callee === "parseFloat") {
@@ -1229,6 +1243,10 @@ export default class VM {
     );
   }
 
+  asyncNearView(contractName, methodName, args, blockId) {
+    return this.near.viewCall(contractName, methodName, args, blockId);
+  }
+
   cachedNearView(contractName, methodName, args, blockId) {
     return this.cachedPromise((onInvalidate) =>
       this.cache.cachedViewCall(
@@ -1246,6 +1264,10 @@ export default class VM {
     return this.cachedPromise((onInvalidate) =>
       this.cache.cachedBlock(this.near, blockId, onInvalidate)
     );
+  }
+
+  asyncFetch(url, options) {
+    return this.cache.asyncFetch(url, options);
   }
 
   cachedFetch(url, options) {


### PR DESCRIPTION
Introducing two new methods:

- `Near.asyncView` - returns a promise to a view call. It doesn't cache the value, so it should only be used within a function to avoid frequent requests on every render.
- `asyncFetch` - returns a promise to `fetch` result. It doesn't cache the value, so it should only be used within a function to avoid frequent requests on every render.

Within the main body of a widget code you shouldn't use either method and instead rely on cached non-async methods (`Near.view` and `fetch`). But async code is required when you have to make an async decision, e.g. to chain a few promises together. Since the VM can't easily switch to support `async` functions with `await`, the best option is to rely on promises which are synchronous within blocks. `Promise.all` can be added later. 

## Example

### Standard cached code (sync):

```jsx
const res = fetch("https://rpc.mainnet.near.org/status");

return res.body;
```

### Async code (just for the example, bad idea to write it this way):

```jsx
if (state.body === undefined) {
  asyncFetch("https://rpc.mainnet.near.org/status").then((res) => {
    State.update({ body: res.body });
  });
}

return state.body;
```

### Example where it makes sense to use async code:
```jsx
function reportUptime() {
  asyncFetch("https://rpc.mainnet.near.org/status").then((res) => {
    const uptime = res.body.uptime_sec;
    Near.call("uptime.near", "reportUptime", { uptime });
  });
}

return <button onClick={reportUptime}>Report Uptime</button>;
```

