### PR TITLE
Social.set and skip confirm toggle

### DIFF
--- a/src/components/Commit.js
+++ b/src/components/Commit.js
@@ -287,30 +287,30 @@ export const CommitButton = (props) => {
     ...rest
   } = props;
 
-  const [showModal, setShowModal] = useState(false);
+  const [computedData, setComputedData] = useState(null);
 
   return (
     <>
       <button
         {...rest}
-        disabled={disabled || showModal || !accountId}
+        disabled={disabled || !data || !!computedData || !accountId}
         onClick={(e) => {
           e.preventDefault();
-          setShowModal(true);
+          setComputedData(typeof data === "function" ? data() : data);
           if (onClick) {
             onClick();
           }
         }}
       >
-        {showModal && Loading}
+        {!!computedData && Loading}
         {children}
       </button>
       <CommitModal
-        show={showModal}
+        show={!!computedData}
         widgetSrc={widgetSrc}
-        data={data}
+        data={computedData}
         force={force}
-        onHide={() => setShowModal(false)}
+        onHide={() => setComputedData(null)}
         onCancel={onCancel}
         onCommit={onCommit}
       />

--- a/src/components/Commit.js
+++ b/src/components/Commit.js
@@ -31,9 +31,9 @@ export const CommitModal = (props) => {
   const accountId = useAccountId();
   const cache = useCache();
 
-  const [commitStarted, setCommitStarted] = useState(false);
+  const [asyncCommitStarted, setAsyncAsyncCommitStarted] = useState(false);
   const [extraStorage, setExtraStorage] = useState(0);
-  const [loading, setLoading] = useState(false);
+  const [commitInProgress, setCommitInProgress] = useState(false);
 
   const [lastData, setLastData] = useState(null);
   const [commit, setCommit] = useState(null);
@@ -77,7 +77,7 @@ export const CommitModal = (props) => {
   }, [writePermission]);
 
   useEffect(() => {
-    if (loading || !showIntent || !accountId || !near) {
+    if (commitInProgress || !showIntent || !accountId || !near) {
       return;
     }
     const jdata = JSON.stringify(data ?? null);
@@ -87,10 +87,10 @@ export const CommitModal = (props) => {
     setLastData(jdata);
     setCommit(null);
     prepareCommit(near, data, force).then(setCommit);
-  }, [loading, data, lastData, force, near, accountId, showIntent]);
+  }, [commitInProgress, data, lastData, force, near, accountId, showIntent]);
 
   const onCommit = async () => {
-    setLoading(true);
+    setCommitInProgress(true);
 
     const newWritePermission =
       giveWritePermission &&
@@ -123,11 +123,12 @@ export const CommitModal = (props) => {
     }
     cache.invalidateCache(commit.data);
     onHide();
-    setLoading(false);
+    setCommitInProgress(false);
   };
 
   if (
-    !commitStarted &&
+    !commitInProgress &&
+    !asyncCommitStarted &&
     commit &&
     showIntent &&
     writePermission &&
@@ -140,14 +141,14 @@ export const CommitModal = (props) => {
           computeWritePermission(writePermission, commit.data[accountId])
         ) === JSON.stringify(writePermission)
       ) {
-        setCommitStarted(true);
-        onCommit().then(() => setCommitStarted(false));
+        setAsyncAsyncCommitStarted(true);
+        onCommit().then(() => setAsyncAsyncCommitStarted(false));
       }
     }
   }
 
   const show =
-    !!commit && showIntent && !commitStarted && writePermission !== null;
+    !!commit && showIntent && !asyncCommitStarted && writePermission !== null;
 
   return (
     <Modal size="xl" centered scrollable show={show} onHide={onCancel}>
@@ -188,7 +189,7 @@ export const CommitModal = (props) => {
                     name="storageDeposit"
                     value={extraStorage}
                     onChange={setExtraStorage}
-                    disabled={loading}
+                    disabled={commitInProgress}
                   >
                     <ToggleButton
                       id="esd-0"
@@ -251,18 +252,18 @@ export const CommitModal = (props) => {
       <Modal.Footer>
         <button
           className="btn btn-success"
-          disabled={!commit?.data || loading}
+          disabled={!commit?.data || commitInProgress}
           onClick={(e) => {
             e.preventDefault();
             onCommit();
           }}
         >
-          {loading && Loading} Save Data
+          {commitInProgress && Loading} Save Data
         </button>
         <button
           className="btn btn-secondary"
           onClick={onCancel}
-          disabled={loading}
+          disabled={commitInProgress}
         >
           Close
         </button>

--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -140,7 +140,7 @@ export function Widget(props) {
     return () => {
       vm.alive = false;
     };
-  }, [src, near, gkey, parsedCode, depth]);
+  }, [src, near, gkey, parsedCode, depth, requestCommit, confirmTransaction]);
 
   useEffect(() => {
     if (!near) {

--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -177,6 +177,10 @@ export function Widget(props) {
             transaction={transaction}
             onHide={() => setTransaction(null)}
           />
+          // <CommitModal
+          // commit={commit}
+          // onHide={() => setTransaction(null)}
+          // />
         }
       </>
     </ErrorBoundary>

--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -13,6 +13,7 @@ import VM from "../../vm/vm";
 import { ErrorFallback, Loading } from "../../data/utils";
 import { ErrorBoundary } from "react-error-boundary";
 import { socialGet, useCache } from "../../data/cache";
+import { CommitModal } from "../Commit";
 
 const AcornOptions = {
   ecmaVersion: 13,
@@ -44,6 +45,7 @@ export function Widget(props) {
   const [context, setContext] = useState({});
   const [vm, setVm] = useState(null);
   const [transaction, setTransaction] = useState(null);
+  const [commitRequest, setCommitRequest] = useState(null);
 
   const cache = useCache();
   const near = useNear();
@@ -98,10 +100,21 @@ export function Widget(props) {
       if (!near) {
         return null;
       }
-      console.log("confirm");
+      console.log("confirm", transaction);
       setTransaction(transaction);
     },
     [near]
+  );
+
+  const requestCommit = useCallback(
+    (commitRequest) => {
+      if (!near || !accountId) {
+        return null;
+      }
+      console.log("commit requested", commitRequest);
+      setCommitRequest(commitRequest);
+    },
+    [near, accountId]
   );
 
   useEffect(() => {
@@ -121,6 +134,7 @@ export function Widget(props) {
       confirmTransaction,
       depth,
       widgetSrc: src,
+      requestCommit,
     });
     setVm(vm);
     return () => {
@@ -172,16 +186,21 @@ export function Widget(props) {
     >
       <>
         {element}
-        {
-          <ConfirmTransaction
-            transaction={transaction}
-            onHide={() => setTransaction(null)}
+        <ConfirmTransaction
+          transaction={transaction}
+          onHide={() => setTransaction(null)}
+        />
+        {commitRequest && (
+          <CommitModal
+            show={true}
+            widgetSrc={src}
+            data={commitRequest.data}
+            force={commitRequest.force}
+            onHide={() => setCommitRequest(null)}
+            onCommit={commitRequest.onCommit}
+            onCancel={commitRequest.onCancel}
           />
-          // <CommitModal
-          // commit={commit}
-          // onHide={() => setTransaction(null)}
-          // />
-        }
+        )}
       </>
     </ErrorBoundary>
   ) : (

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -283,3 +283,40 @@ export const indexMatch = (action, key, data) => {
     }
   });
 };
+
+const KnownSecondLevelKeys = {
+  graph: true,
+  post: true,
+  index: true,
+  settings: true,
+};
+
+export const computeWritePermission = (previousPermissions, data) => {
+  const permissions = isObject(previousPermissions)
+    ? JSON.parse(JSON.stringify(previousPermissions))
+    : {};
+
+  if (isObject(data)) {
+    Object.entries(data).forEach(([key, value]) => {
+      if (key in KnownSecondLevelKeys) {
+        if (isObject(value)) {
+          const subPermissions = (permissions[key] = permissions[key] || {});
+          Object.keys(value).forEach((key) => {
+            subPermissions[key] = true;
+          });
+        } else {
+          permissions[key] = true;
+        }
+      } else {
+        permissions[key] = true;
+      }
+    });
+  }
+
+  // console.log(
+  //   JSON.stringify(previousPermissions),
+  //   JSON.stringify(data),
+  //   JSON.stringify(permissions)
+  // );
+  return permissions;
+};

--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -378,7 +378,11 @@ class VmStack {
     if (element === "Widget") {
       return <Widget {...attributes} />;
     } else if (element === "CommitButton") {
-      return <CommitButton {...attributes}>{children}</CommitButton>;
+      return (
+        <CommitButton {...attributes} widgetSrc={this.vm.widgetSrc}>
+          {children}
+        </CommitButton>
+      );
     } else if (element === "InfiniteScroll") {
       return <InfiniteScroll {...attributes}>{children}</InfiniteScroll>;
     } else if (element === "Tooltip") {
@@ -486,6 +490,11 @@ class VmStack {
           );
         }
         return this.vm.cachedIndex(args[0], args[1], args[2]);
+      } else if (keyword === "Social" && callee === "set") {
+        if (args.length < 1) {
+          throw new Error("Missing argument 'data' for Social.set");
+        }
+        return this.vm.socialSet(args[0], args[1]);
       } else if (keyword === "Near" && callee === "view") {
         if (args.length < 2) {
           throw new Error(
@@ -1174,6 +1183,7 @@ export default class VM {
       confirmTransaction,
       depth,
       widgetSrc,
+      requestCommit,
     } = options;
 
     if (!code) {
@@ -1191,6 +1201,7 @@ export default class VM {
     this.confirmTransaction = confirmTransaction;
     this.depth = depth;
     this.widgetSrc = widgetSrc;
+    this.requestCommit = requestCommit;
   }
 
   cachedPromise(promise) {
@@ -1280,6 +1291,15 @@ export default class VM {
     return this.cachedPromise((onInvalidate) =>
       this.cache.socialIndex(action, key, options, onInvalidate)
     );
+  }
+
+  socialSet(data, options) {
+    return this.requestCommit({
+      data,
+      force: options?.force,
+      onCommit: options?.onCommit,
+      onCancel: options?.onCancel,
+    });
   }
 
   renderCode({ props, context, state }) {


### PR DESCRIPTION
This PR brings two big changes.

### 1. Introducing `Social.set`

Takes `data` object and commits it to SocialDB. It works similarly to the `CommitButton` by spawning the modal window prompt to save data, but it doesn't have to be triggered through the commit button component. It allows you to write more flexible code that relies on async promises and use other events and components. Overall it enables more flexibility when committing to SocialDB. For example, you can commit when Enter key pressed.

Arguments:
 - `data` required, the data object to be committed. Similar to `CommitButton`, it shouldn't start with account ID.
 - `options` optional object
   - `force`, whether to overwrite the data
   - `onCommit` - function to trigger on successful commit. Will pass the data that was written (including accountID)
   - `onCancel` - function to trigger if the user cancels the commit.

### 2. Ability to skip confirmation.

When a modal window to confirm a commit is shown, it has a toggle to select whether you want to confirm the action every time, or don't show the confirm window for the similar data. By default for the new data, the toggle is set to on, which means the user will not be prompted to confirm the data for the next time. It remembers the decision locally and will be default to this decision next time (in case the user decides to not skip). If user approves the commit with the toggle on, then the next commit with the similar data will skip the confirmation window. The permission is given per widget src.

Similar data means, the same top level keys on the data. Except for the 4 top level keys: ` graph`, `post`, `index` and `settings`. For these keys, the second level key will be used. More keys can be added later, once new standards added.

For example the follow button widget uses the following keys:
```json
{
    "graph": {
      "follow": ...
    },
    "index": {
      "graph": ...
      "notify": ...
    }
  }
```

If it attempts to modify something else, the confirmation modal will be shown again.

<img width="798" alt="Screen Shot 2022-12-03 at 10 35 55 AM" src="https://user-images.githubusercontent.com/470453/205456503-7c0db525-7f61-4ead-8591-2b6d86065fa4.png">

### Example

Example on using `CommitButton` and `Social.set` with regular button. Note, both use `force`

```jsx
State.init({ commitLoading: false });

const data = { experimental: { test: "test" } };

const Loading = (
  <span
    className="spinner-grow spinner-grow-sm me-1"
    role="status"
    aria-hidden="true"
  />
);

return (
  <div>
    <CommitButton force data={data}>
      CommitButton
    </CommitButton>
    <button
      disabled={state.commitLoading}
      onClick={() => {
        State.update({ commitLoading: true });
        Social.set(data, {
          force: true,
          onCommit: () => {
            State.update({ commitLoading: false });
          },
          onCancel: () => {
            State.update({ commitLoading: false });
          },
        });
      }}
    >
      {state.commitLoading && Loading}Social.set
    </button>
  </div>
);
```