### PR TITLE
feat: update sidebar to get to edit route quickly call it workspace

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -76,6 +76,11 @@ export function Sidebar(props) {
                     New widget
                   </Link>
                 </li>
+                <li>
+                  <Link className="dropdown-item" to="/edit">
+                    Editor
+                  </Link>
+                </li>
                 {widgetSrc?.edit && (
                   <li>
                     <Link


### PR DESCRIPTION
Currently to get to edit route quickly requires hitting new widget, would be nice to just get there when navigating the app.  Calling it workspace for now.