### PR TITLE
Add subscribe option to VM

### DIFF
--- a/src/data/cache.js
+++ b/src/data/cache.js
@@ -1,5 +1,5 @@
 import { NearConfig } from "./near";
-import { indexMatch, patternMatch } from "./utils";
+import { indexMatch, isObject, patternMatch } from "./utils";
 import { openDB } from "idb";
 import { singletonHook } from "react-singleton-hook";
 
@@ -17,7 +17,8 @@ const CacheStatus = {
   Invalidated: "Invalidated",
 };
 
-const CacheDebug = false;
+const CacheSubscriptionTimeoutMs = 5000;
+const CacheDebug = true;
 
 function invalidateCallbacks(cached, isFinal) {
   if (cached.invalidationCallbacks?.length) {
@@ -59,7 +60,7 @@ class Cache {
     return (await this.dbPromise).put(CacheDbObject, val, key);
   }
 
-  cachedPromise(key, promise, onInvalidate, forceCachedValue) {
+  cachedPromise(key, promise, invalidate, forceCachedValue) {
     key = JSON.stringify(key);
     const cached = this.cache[key] || {
       status: CacheStatus.NotStarted,
@@ -67,8 +68,28 @@ class Cache {
       result: null,
     };
     this.cache[key] = cached;
-    if (onInvalidate) {
-      cached.invalidationCallbacks.push(onInvalidate);
+    if (!isObject(invalidate)) {
+      invalidate = {
+        onInvalidate: invalidate,
+      };
+    }
+    if (invalidate.onInvalidate) {
+      cached.invalidationCallbacks.push(invalidate.onInvalidate);
+    }
+    if (!cached.subscription && invalidate.subscribe) {
+      const makeTimer = () => {
+        cached.subscription = setTimeout(() => {
+          CacheDebug && console.log("Cached subscription invalidation", key);
+          if (document.hidden) {
+            makeTimer();
+          } else {
+            cached.subscription = null;
+            cached.status = CacheStatus.Invalidated;
+            invalidateCallbacks(cached, false);
+          }
+        }, CacheSubscriptionTimeoutMs);
+      };
+      makeTimer();
     }
     if (
       cached.status === CacheStatus.InProgress ||
@@ -167,18 +188,18 @@ class Cache {
     });
   }
 
-  cachedBlock(near, blockId, onInvalidate) {
+  cachedBlock(near, blockId, invalidate) {
     return this.cachedPromise(
       {
         action: Action.Block,
         blockId,
       },
       () => near.block(blockId),
-      onInvalidate
+      invalidate
     );
   }
 
-  cachedViewCall(near, contractId, methodName, args, blockId, onInvalidate) {
+  cachedViewCall(near, contractId, methodName, args, blockId, invalidate) {
     return this.cachedPromise(
       {
         action: Action.ViewCall,
@@ -188,7 +209,7 @@ class Cache {
         blockId,
       },
       () => near.viewCall(contractId, methodName, args, blockId),
-      onInvalidate
+      invalidate
     );
   }
 
@@ -222,7 +243,7 @@ class Cache {
     }
   }
 
-  cachedFetch(url, options, onInvalidate) {
+  cachedFetch(url, options, invalidate) {
     return this.cachedPromise(
       {
         action: Action.Fetch,
@@ -230,11 +251,11 @@ class Cache {
         options,
       },
       () => this.asyncFetch(url, options),
-      onInvalidate
+      invalidate
     );
   }
 
-  socialGet(near, keys, recursive, blockId, options, onInvalidate) {
+  socialGet(near, keys, recursive, blockId, options, invalidate) {
     if (!near) {
       return null;
     }
@@ -250,7 +271,7 @@ class Cache {
       "get",
       args,
       blockId,
-      onInvalidate
+      invalidate
     );
     if (data === null) {
       return null;
@@ -270,7 +291,7 @@ class Cache {
     return data;
   }
 
-  socialIndex(action, key, options, onInvalidate) {
+  socialIndex(action, key, options, invalidate) {
     const res = this.cachedFetch(
       `${NearConfig.apiUrl}/index`,
       {
@@ -284,13 +305,13 @@ class Cache {
           options,
         }),
       },
-      onInvalidate
+      invalidate
     );
 
     return res?.ok ? res.body : null;
   }
 
-  localStorageGet(domain, key, onInvalidate) {
+  localStorageGet(domain, key, invalidate) {
     return this.cachedPromise(
       {
         action: Action.LocalStorage,
@@ -298,7 +319,7 @@ class Cache {
         key,
       },
       undefined,
-      onInvalidate,
+      invalidate,
       true
     );
   }

--- a/src/data/cache.js
+++ b/src/data/cache.js
@@ -18,7 +18,7 @@ const CacheStatus = {
 };
 
 const CacheSubscriptionTimeoutMs = 5000;
-const CacheDebug = true;
+const CacheDebug = false;
 
 function invalidateCallbacks(cached, isFinal) {
   if (cached.invalidationCallbacks?.length) {


### PR DESCRIPTION
All cached VM methods got a new option to subscribe to the query. Currently, it's implemented as a 5 seconds timer, at which the data is refreshed for all subscribers.

Methods that are updated, with examples for subscribing:
- `Near.view(contractName, methodName, viewArg, blockId, subscribe)` needs `subscribe` to be `true`.
- `Near.block(blockId, subscribe)` needs `subscribe` to be `true`.
- `fetch(url, options)`, needs `options.subscribe` to be `true`.
- `Social.get(keys, blockId, options)`, needs `options.subscribe` to be `true`.
- `Social.getr(keys, blockId, options)`, needs `options.subscribe` to be `true`.
- `Social.keys(keys, blockId, options)`, needs `options.subscribe` to be `true`.
- `Social.index(action, key, options)`, needs `options.subscribe` to be `true`.

Example:
```jsx
const res = fetch("https://rpc.mainnet.near.org/status", {
  subscribe: true,
});

return res.body.sync_info.latest_block_height;
```