### PR TITLE
Add Map and Set objects

### DIFF
--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -159,6 +159,8 @@ const Keywords = {
   Array,
   BN,
   Uint8Array,
+  Map,
+  Set,
   clipboard: true,
 };
 
@@ -195,6 +197,13 @@ const assertValidObject = (o) => {
 const deepCopy = (o) => {
   if (Array.isArray(o)) {
     return o.map((v) => deepCopy(v));
+  } else if (o instanceof Map) {
+    return new Map(
+      [...o.entries()].map(([k, v]) => [deepCopy(k), deepCopy(v)])
+    );
+  }
+  if (o instanceof Set) {
+    return new Set([...o].map((v) => deepCopy(v)));
   } else if (Buffer.isBuffer(o)) {
     return Buffer.from(o);
   } else if (o instanceof Uint8Array || o instanceof ArrayBuffer) {


### PR DESCRIPTION
Expose `Map` and `Set` keywords. Add them to deepCopy.

```jsx
const map1 = new Map();

map1.set("a", 1);
map1.set("b", 2);
map1.set("c", 3);

console.log(map1.get("a"));
// expected output: 1

map1.set("a", 97);

console.log(map1.get("a"));
// expected output: 97

console.log(map1.size);
// expected output: 3

map1.delete("b");

console.log(map1.size);
// expected output: 2

const mySet1 = new Set();

mySet1.add(1); // Set(1) { 1 }
mySet1.add(5); // Set(2) { 1, 5 }
mySet1.add(5); // Set(2) { 1, 5 }
mySet1.add("some text"); // Set(3) { 1, 5, 'some text' }
const o = { a: 1, b: 2 };
mySet1.add(o);

mySet1.add({ a: 1, b: 2 }); // o is referencing a different object, so this is okay

mySet1.has(1); // true
mySet1.has(3); // false, since 3 has not been added to the set
mySet1.has(5); // true
mySet1.has(Math.sqrt(25)); // true
mySet1.has("Some Text".toLowerCase()); // true
mySet1.has(o); // true

mySet1.size; // 5

mySet1.delete(5); // removes 5 from the set
mySet1.has(5); // false, 5 has been removed

mySet1.size; // 4, since we just removed one value

mySet1.add(5); // Set(5) { 1, 'some text', {...}, {...}, 5 } - a previously deleted item will be added as a new item, it will not retain its original position before deletion

console.log(mySet1); // Set(5) { 1, "some text", {…}, {…}, 5 }
```

Fixes: #87 