### PR TITLE
Fix commitData without limited access key

### DIFF
--- a/src/data/commitData.js
+++ b/src/data/commitData.js
@@ -106,6 +106,7 @@ export const requestPermissionAndCommit = async (near, data, deposit) => {
         deposit: deposit.gt(0) ? deposit.toFixed(0) : "1",
       },
     });
+    deposit = Big(0);
   }
   actions.push({
     type: "FunctionCall",
@@ -115,7 +116,7 @@ export const requestPermissionAndCommit = async (near, data, deposit) => {
         data,
       },
       gas: TGas.mul(100).toFixed(0),
-      deposit: "1",
+      deposit: deposit.gt(0) ? deposit.toFixed(0) : "1",
     },
   });
   return await wallet.signAndSendTransaction({


### PR DESCRIPTION
Some wallets don't provide a limited access key from wallet selector. In this case we can't request the write permission for the key. The fallback was not attaching the deposit properly.