### PR TITLE
Filter out non-valid characters from Open/Rename modals

### DIFF
--- a/src/components/Editor/OpenModal.js
+++ b/src/components/Editor/OpenModal.js
@@ -23,7 +23,9 @@ export default function OpenModal(props) {
           id="widget-src-input"
           type="text"
           value={widgetSrc}
-          onChange={(e) => setWidgetSrc(e.target.value)}
+          onChange={(e) =>
+            setWidgetSrc(e.target.value.replaceAll(/[^a-zA-Z0-9_.\-\/]/g, ""))
+          }
         />
       </Modal.Body>
       <Modal.Footer>
@@ -41,6 +43,7 @@ export default function OpenModal(props) {
         </button>
         <button
           className="btn btn-outline-success"
+          disabled={widgetSrc && widgetSrc.indexOf("/") !== -1}
           onClick={(e) => {
             e.preventDefault();
             onNew(widgetSrc);

--- a/src/components/Editor/RenameModal.js
+++ b/src/components/Editor/RenameModal.js
@@ -23,7 +23,9 @@ export default function RenameModal(props) {
           id="rename-input"
           type="text"
           value={newName}
-          onChange={(e) => setNewName(e.target.value)}
+          onChange={(e) =>
+            setNewName(e.target.value.replaceAll(/[^a-zA-Z0-9_.\-]/g, ""))
+          }
         />
       </Modal.Body>
       <Modal.Footer>


### PR DESCRIPTION
Fixes #74

Only allowed characters can now be entered in Open/Rename modals