### PR TITLE
Allow use toLocaleString()

### DIFF
--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -177,7 +177,7 @@ const ReservedKeys = {
 };
 
 const assertNotReservedKey = (key) => {
-  if (key !== "toString" && key in ReservedKeys) {
+  if (ReservedKeys[key] === true) {
     throw new Error(`${key} is reserved and can't be used`);
   }
 };


### PR DESCRIPTION
Previously all default JS properties were prohibited. Switches to proper blacklist instead.

```jsx
const a = new Date().toLocaleString();
const b = new Date().toString();
let c = "err";
try {
  c = new Date().constructor();
} catch (e) {
  c = e.message;
}
return [a, b, c];
```