### PR TITLE
Add onMention to Markdown tag that parses Near's account IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "homepage": "/",
   "private": true,
   "dependencies": {
@@ -41,7 +41,8 @@
     "react-uuid": "^1.0.2",
     "remark-gfm": "^3.0.1",
     "styled-components": "^5.3.6",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "mdast-util-find-and-replace": "^2.0.0"
   },
   "scripts": {
     "serve": "webpack serve",

--- a/src/components/Markdown.js
+++ b/src/components/Markdown.js
@@ -3,9 +3,7 @@ import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { tomorrow } from "react-syntax-highlighter/dist/esm/styles/prism";
 import React from "react";
-import { mentions, mentionRegex } from "./remark/mentions";
-import { isString } from "../data/utils";
-
+import mentions from "./remark/mentions";
 export const Markdown = (props) => {
   const { onLinkClick, text, onMention, ...rest } = props;
   return (
@@ -14,13 +12,8 @@ export const Markdown = (props) => {
       plugins={[gfm, mentions]}
       components={{
         strong({ node, children, ...props }) {
-          if (onMention && children.length === 1 && isString(children[0])) {
-            mentionRegex.lastIndex = 0;
-            const match = mentionRegex.exec(children[0]);
-            const accountId = match?.[1];
-            if (accountId && accountId.length >= 2 && accountId.length <= 64) {
-              return onMention(accountId);
-            }
+          if (onMention && node.properties?.accountId) {
+            return onMention(node.properties?.accountId);
           }
           return <strong {...props}>{children}</strong>;
         },

--- a/src/components/remark/mentions.js
+++ b/src/components/remark/mentions.js
@@ -1,0 +1,32 @@
+import { findAndReplace } from "mdast-util-find-and-replace";
+
+export const mentionRegex =
+  /@((?:(?:[a-z\d]+[-_])*[a-z\d]+.)*(?:[a-z\d]+[-_])*[a-z\d]+)/gi;
+
+export function mentions() {
+  function replace(value, username, match) {
+    if (
+      /[\w`]/.test(match.input.charAt(match.index - 1)) ||
+      /[/\w`]/.test(match.input.charAt(match.index + value.length)) ||
+      username.length < 3 ||
+      username.length > 64
+    ) {
+      return false;
+    }
+
+    let node = { type: "text", value };
+    node = {
+      type: "strong",
+      children: [node],
+    };
+
+    return node;
+  }
+
+  function transform(markdownAST) {
+    findAndReplace(markdownAST, mentionRegex, replace);
+    return markdownAST;
+  }
+
+  return transform;
+}

--- a/src/components/remark/mentions.js
+++ b/src/components/remark/mentions.js
@@ -1,9 +1,9 @@
 import { findAndReplace } from "mdast-util-find-and-replace";
 
-export const mentionRegex =
+const mentionRegex =
   /@((?:(?:[a-z\d]+[-_])*[a-z\d]+.)*(?:[a-z\d]+[-_])*[a-z\d]+)/gi;
 
-export function mentions() {
+export default function mentions() {
   function replace(value, username, match) {
     if (
       /[\w`]/.test(match.input.charAt(match.index - 1)) ||
@@ -18,6 +18,9 @@ export function mentions() {
     node = {
       type: "strong",
       children: [node],
+      data: {
+        hProperties: { accountId: username },
+      },
     };
 
     return node;


### PR DESCRIPTION
- Introduce mentions to Markdown component.
By default it turns `@mob.near` into bold, but if `onMention` is passed, it calls it with the accountId instead.

Example code:
```jsx
const renderMention =
  ((accountId) => (
    <Widget
      src="mob.near/widget/ProfileLine"
      props={{ accountId, hideAccountId: true, tooltip: true }}
    />
  ));

return <Markdown text="Hi @root.near" onMention={renderMention} />;
```