### PR TITLE
Introduce useCache

### DIFF
--- a/src/data/cache.js
+++ b/src/data/cache.js
@@ -8,6 +8,7 @@ const Action = {
   Fetch: "Fetch",
   Block: "Block",
   LocalStorage: "LocalStorage",
+  CustomPromise: "CustomPromise",
 };
 
 const CacheStatus = {
@@ -262,6 +263,17 @@ class Cache {
         options,
       },
       () => this.asyncFetch(url, options),
+      invalidate
+    );
+  }
+
+  cachedCustomPromise(key, promise, invalidate) {
+    return this.cachedPromise(
+      {
+        action: Action.CustomPromise,
+        key,
+      },
+      () => promise(),
       invalidate
     );
   }

--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -664,6 +664,18 @@ class VmStack {
           );
         }
         return this.vm.asyncFetch(...args);
+      } else if (callee === "useCache") {
+        if (args.length < 2) {
+          throw new Error(
+            "Method: useCache. Required arguments: 'promiseGenerator', 'dataKey'. Optional: 'options'"
+          );
+        }
+        if (!(args[0] instanceof Function)) {
+          throw new Error(
+            "Method: useCache. The first argument 'promiseGenerator' must be a function"
+          );
+        }
+        return this.vm.useCache(...args);
       } else if (callee === "parseInt") {
         return parseInt(...args);
       } else if (callee === "parseFloat") {
@@ -1567,6 +1579,21 @@ export default class VM {
   cachedIndex(action, key, options) {
     return this.cachedPromise(
       (invalidate) => this.cache.socialIndex(action, key, options, invalidate),
+      options?.subscribe
+    );
+  }
+
+  useCache(promiseGenerator, dataKey, options) {
+    return this.cachedPromise(
+      (invalidate) =>
+        this.cache.cachedCustomPromise(
+          {
+            widgetSrc: this.widgetSrc,
+            dataKey,
+          },
+          promiseGenerator,
+          invalidate
+        ),
       options?.subscribe
     );
   }


### PR DESCRIPTION
## Introduce global method `useCache`.

The method acts like a hook that takes a promise through a generator function, fetches the data and caches it. The cache is global for the VM, but it's identified by for given widget (by src) for a given `dataKey`.
It can be used to easily use and cache data from async data sources.

**Arguments:**
- `promiseGenerator` - a function that returns a promise, which generates data. Note, you don't return the promise directly, because it should only be fired once.
- `dataKey` - the unique name (within the current widget) to identify the data.
- `options` - optional argument:
  - `subscribe` - if `true` - the data refreshes periodically by invalidating cache.

**Returns** `null` if the cache is cold and data is fetching, or the previous cached value while the data is being fetched an d, or the new data if the new promise data is different from the old data.

Note: the data is being cached and compared as JSON serialized objects.

```jsx
const status = useCache(
  () =>
    asyncFetch("https://rpc.mainnet.near.org/status").then((res) => res.body),
  "mainnetRpcStatus",
  { subscribe: true }
);

return status;
```