### PR TITLE
Ability to browse and act as a different account

### DIFF
--- a/src/components/icons/Pretend.js
+++ b/src/components/icons/Pretend.js
@@ -1,0 +1,24 @@
+import React from "react";
+
+export function Pretend() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <path
+        strokeWidth="0.3px"
+        fill="#697177"
+        d="M1.5 1a.5.5 0 0 0-.5.5v3a.5.5 0 0 1-1 0v-3A1.5 1.5 0 0 1 1.5 0h3a.5.5 0 0 1 0 1h-3zM11 .5a.5.5 0 0 1 .5-.5h3A1.5 1.5 0 0 1 16 1.5v3a.5.5 0 0 1-1 0v-3a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 1-.5-.5zM.5 11a.5.5 0 0 1 .5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 1 0 1h-3A1.5 1.5 0 0 1 0 14.5v-3a.5.5 0 0 1 .5-.5zm15 0a.5.5 0 0 1 .5.5v3a1.5 1.5 0 0 1-1.5 1.5h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 1 .5-.5z"
+      />
+      <path
+        strokeWidth="0.3px"
+        fill="#697177"
+        d="M3 14s-1 0-1-1 1-4 6-4 6 3 6 4-1 1-1 1H3zm8-9a3 3 0 1 1-6 0 3 3 0 0 1 6 0z"
+      />
+    </svg>
+  );
+}

--- a/src/components/icons/StopPretending.js
+++ b/src/components/icons/StopPretending.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+export function StopPretending() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+    >
+      <path
+        strokeWidth="0.3px"
+        fill="#697177"
+        d="M13.879 10.414a2.501 2.501 0 0 0-3.465 3.465l3.465-3.465Zm.707.707-3.465 3.465a2.501 2.501 0 0 0 3.465-3.465Zm-4.56-1.096a3.5 3.5 0 1 1 4.949 4.95 3.5 3.5 0 0 1-4.95-4.95ZM11 5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm-9 8c0 1 1 1 1 1h5.256A4.493 4.493 0 0 1 8 12.5a4.49 4.49 0 0 1 1.544-3.393C9.077 9.038 8.564 9 8 9c-5 0-6 3-6 4Z"
+      />
+    </svg>
+  );
+}

--- a/src/components/navigation/PretendModal.js
+++ b/src/components/navigation/PretendModal.js
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+import Modal from "react-bootstrap/Modal";
+import { NearConfig } from "../../data/near";
+import { useAccount } from "../../data/account";
+import { Widget } from "../Widget/Widget";
+
+export default function PretendModal(props) {
+  const account = useAccount();
+  const onHide = props.onHide;
+  const show = props.show;
+
+  const [accountId, setAccountId] = useState("");
+
+  return (
+    <Modal centered show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Pretend to be another account</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div>
+          <label htmlFor="widget-src-input" className="form-label">
+            Pretend to be account ID:
+          </label>
+          <input
+            className="form-control"
+            id="widget-src-input"
+            type="text"
+            value={accountId}
+            onChange={(e) =>
+              setAccountId(
+                e.target.value.toLowerCase().replaceAll(/[^a-z0-9_.\-]/g, "")
+              )
+            }
+          />
+        </div>
+        <div className="mt-2">
+          <Widget
+            src={NearConfig.widgets.profileInlineBlock}
+            props={{ accountId }}
+          />
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <button
+          className="btn btn-success"
+          disabled={!accountId || !account.startPretending}
+          onClick={(e) => {
+            e.preventDefault();
+            account.startPretending(accountId);
+            setAccountId("");
+            onHide();
+          }}
+        >
+          Pretend
+        </button>
+        <button className="btn btn-secondary" onClick={onHide}>
+          Cancel
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/navigation/desktop/DevActionsDropdown.js
+++ b/src/components/navigation/desktop/DevActionsDropdown.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { Link } from "react-router-dom";
 import { Fork } from "../../icons/Fork";
 import { Code } from "../../icons/Code";
+import { useAccount } from "../../../data/account";
 
 const StyledDropdown = styled.div`
   .dropdown-toggle {
@@ -84,6 +85,8 @@ const StyledDropdown = styled.div`
 `;
 
 export function DevActionsDropdown(props) {
+  const account = useAccount();
+
   if (props.widgetSrc?.edit || props.widgetSrc?.view) {
     return (
       <StyledDropdown className="dropdown">
@@ -105,9 +108,7 @@ export function DevActionsDropdown(props) {
             <li>
               <Link to={`/edit/${props.widgetSrc?.edit}`}>
                 <Fork />
-                {props.widgetSrc.edit.startsWith(
-                  `${props.signedAccountId}/widget/`
-                )
+                {props.widgetSrc.edit.startsWith(`${account.accountId}/widget/`)
                   ? "Edit widget"
                   : "Fork widget"}
               </Link>

--- a/src/components/navigation/desktop/UserDropdown.js
+++ b/src/components/navigation/desktop/UserDropdown.js
@@ -131,7 +131,11 @@ export function UserDropdown(props) {
             <div className="profile-username">{account.accountId}</div>
           </div>
         </button>
-        <ul className="dropdown-menu" aria-labelledby="dropdownMenu2222">
+        <ul
+          className="dropdown-menu"
+          aria-labelledby="dropdownMenu2222"
+          style={{ minWidth: "fit-content" }}
+        >
           <li>
             <NavLink
               className="dropdown-item"

--- a/src/components/navigation/desktop/UserDropdown.js
+++ b/src/components/navigation/desktop/UserDropdown.js
@@ -6,6 +6,10 @@ import { LogOut } from "../../icons/LogOut";
 import { Withdraw } from "../../icons/Withdraw";
 import { NavLink } from "react-router-dom";
 import { TGas, useNear } from "../../../data/near";
+import { useAccount } from "../../../data/account";
+import PretendModal from "../PretendModal";
+import { Pretend } from "../../icons/Pretend";
+import { StopPretend, StopPretending } from "../../icons/StopPretending";
 
 const StyledDropdown = styled.div`
   button,
@@ -92,69 +96,102 @@ const StyledDropdown = styled.div`
 
 export function UserDropdown(props) {
   const near = useNear();
+  const account = useAccount();
 
   const withdrawStorage = useCallback(async () => {
     await near.contract.storage_withdraw({}, TGas.mul(30).toFixed(0), "1");
   }, [near]);
 
+  const [showPretendModal, setShowPretendModal] = React.useState(false);
+
   return (
-    <StyledDropdown className="dropdown">
-      <button
-        className="dropdown-toggle"
-        type="button"
-        id="dropdownMenu2222"
-        data-bs-toggle="dropdown"
-        aria-expanded="false"
-      >
-        <Widget
-          src={props.NearConfig.widgets.profileImage}
-          props={{
-            accountId: props.signedAccountId,
-            className: "d-inline-block",
-            style: { width: "40px", height: "40px" },
-          }}
-        />
-        <div className="profile-info">
-          {props.NearConfig.widgets.profileName && (
-            <div className="profile-name">
-              <Widget src={props.NearConfig.widgets.profileName} />
-            </div>
+    <>
+      <StyledDropdown className="dropdown">
+        <button
+          className="dropdown-toggle"
+          type="button"
+          id="dropdownMenu2222"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+        >
+          <Widget
+            src={props.NearConfig.widgets.profileImage}
+            props={{
+              accountId: account.accountId,
+              className: "d-inline-block",
+              style: { width: "40px", height: "40px" },
+            }}
+          />
+          <div className="profile-info">
+            {props.NearConfig.widgets.profileName && (
+              <div className="profile-name">
+                <Widget src={props.NearConfig.widgets.profileName} />
+              </div>
+            )}
+            <div className="profile-username">{account.accountId}</div>
+          </div>
+        </button>
+        <ul className="dropdown-menu" aria-labelledby="dropdownMenu2222">
+          <li>
+            <NavLink
+              className="dropdown-item"
+              type="button"
+              to={`/${props.NearConfig.widgets.profilePage}?accountId=${account.accountId}`}
+            >
+              <User />
+              My Profile
+            </NavLink>
+          </li>
+          <li>
+            <button
+              className="dropdown-item"
+              type="button"
+              onClick={() => withdrawStorage()}
+            >
+              <Withdraw />
+              Withdraw {props.availableStorage.div(1000).toFixed(2)}kb
+            </button>
+          </li>
+          {account.pretendAccountId ? (
+            <li>
+              <button
+                className="dropdown-item"
+                type="button"
+                disabled={!account.startPretending}
+                onClick={() => account.startPretending(undefined)}
+              >
+                <StopPretending />
+                Stop pretending
+              </button>
+            </li>
+          ) : (
+            <li>
+              <button
+                className="dropdown-item"
+                type="button"
+                onClick={() => setShowPretendModal(true)}
+              >
+                <Pretend />
+                Pretend to be another account
+              </button>
+            </li>
           )}
-          <div className="profile-username">{props.signedAccountId}</div>
-        </div>
-      </button>
-      <ul className="dropdown-menu" aria-labelledby="dropdownMenu2222">
-        <li>
-          <NavLink
-            className="dropdown-item"
-            type="button"
-            to={`/${props.NearConfig.widgets.profilePage}?accountId=${props.signedAccountId}`}
-          >
-            <User />
-            My Profile
-          </NavLink>
-        </li>
-        <li>
-          <button
-            className="dropdown-item"
-            type="button"
-            onClick={() => withdrawStorage()}
-          >
-            <Withdraw />
-            Withdraw {props.availableStorage.div(1000).toFixed(2)}kb
-          </button>
-        </li>
-        <li>
-          <button
-            className="dropdown-item"
-            type="button"
-            onClick={() => props.logOut()}
-          >
-            <LogOut />
-            Sign Out
-          </button>
-        </li>
-      </ul>
-    </StyledDropdown>
+          <li>
+            <button
+              className="dropdown-item"
+              type="button"
+              onClick={() => props.logOut()}
+            >
+              <LogOut />
+              Sign Out
+            </button>
+          </li>
+        </ul>
+      </StyledDropdown>
+      <PretendModal
+        show={showPretendModal}
+        onHide={() => setShowPretendModal(false)}
+      />
+    </>
   );
 }

--- a/src/data/near.js
+++ b/src/data/near.js
@@ -19,16 +19,14 @@ export const randomPublicKey = nearAPI.utils.PublicKey.from(
   "ed25519:8fWHD35Rjd78yeowShh9GwhRudRtLLsGCRjZtgPjAtw9"
 );
 
-const MainnetDomains = {
-  "view.social08.org": true,
-  "near.social": true,
-  "social.near.page": true,
-  localhost: true,
+const TestnetDomains = {
+  "test.near.social": true,
+  "127.0.0.1": true,
 };
 
 const EnableWeb4FastRpc = false;
 
-export const IsMainnet = window.location.hostname in MainnetDomains;
+export const IsMainnet = !(window.location.hostname in TestnetDomains);
 const TestnetContract = "v1.social08.testnet";
 const TestNearConfig = {
   networkId: "testnet",
@@ -72,6 +70,7 @@ export const MainNearConfig = {
     profilePage: "mob.near/widget/ProfilePage",
     profileName: "patrick.near/widget/ProfileName",
     editorComponentSearch: "mob.near/widget/Editor.ComponentSearch",
+    profileInlineBlock: "mob.near/widget/Profile.InlineBlock",
   },
   apiUrl: "https://api.near.social",
   finalSynchronizationDelayMs: 3000,


### PR DESCRIPTION
Adds a button to the desktop menu to act as a different account. If you attempt to commit the data, it will be submitted from your original account, but on behalf of the pretended account. The write permission is required to commit data.