### PR TITLE
Ability to recursively redirect widget's src

### DIFF
--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -440,6 +440,9 @@ class VmStack {
       }
     } else if (element === "Widget") {
       attributes.depth = this.vm.depth + 1;
+      attributes.config = [attributes.config, ...this.vm.widgetConfigs].filter(
+        Boolean
+      );
     }
 
     if (withChildren === false && code.children.length) {
@@ -1460,6 +1463,7 @@ export default class VM {
       widgetSrc,
       requestCommit,
       version,
+      widgetConfigs,
     } = options;
 
     if (!code) {
@@ -1479,6 +1483,7 @@ export default class VM {
     this.requestCommit = requestCommit;
     this.version = version;
     this.cachedStyledComponents = new Map();
+    this.widgetConfigs = widgetConfigs;
   }
 
   cachedPromise(promise, subscribe) {


### PR DESCRIPTION
Introduce `config` property on the `Widget` component. It allows you to recursively redirect widgets' `src` to a different `src` or code itself.

The config may contain two properties:
- `redirectMap` (optional) - has to be an object that maps from `src` to `SrcOrCode` value.
- `redirect` (optional) - a function that will be called if `redirectMap` doesn't have `src`. The function receives `src` and should return `SrcOrCode` value or `null` (in case of no redirect).

`SrcOrCode` represents either `src` (string value) or `{ code }` object with key `code` and string value. Examples:
- `"mob.near/widget/TimeAgo"` - the `src`
- `{ code: "return \"No likes for you!\""}` - the code to be passed to the widget instead of the `src`

When child widget specifies `config`, the its config will be evaluated first. Then if the parent widget had a config, it will be evaluated next, an so on. Once the `src` changes to the code object, it doesn't continue redirect evaluations.

```jsx
return (
  <Widget
    src="mob.near/widget/MainPage.Feed"
    config={{
      redirectMap: {
        "mob.near/widget/TimeAgo": "gov.near/widget/TimeAgo",
        "mob.near/widget/LikeButton": {
          code: `return "No likes for you!"`,
        },
      },
      redirect: (src) => {
        if (src.startsWith("alice.near/")) {
          return src.replace("alice.near/", "bob.near/");
        }
        return null;
      },
    }}
    props={{}}
  />
);
```