### PR TITLE
Add 'Open in VS Code' button

### DIFF
--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -597,6 +597,14 @@ export default function EditorPage(props) {
                       Open Component in a new tab
                     </a>
                   )}
+                    <a
+                      className="btn btn-outline-primary"
+                      href="vscode:extension/maxistyping.near"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Open in VS Code
+                    </a>
                 </div>
               </div>
               <div className={`${tab === Tab.Props ? "" : "visually-hidden"}`}>


### PR DESCRIPTION
This button navigates users to the VS Code extension. Ideally this button should also run `near.openWidgetsFromAccount` command but I couldn't find the way how to do that.

Relates: https://pagodaplatform.atlassian.net/browse/DEC-834