### PR TITLE
Safely support styled-components "as" prop

### DIFF
--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -428,9 +428,12 @@ class VmStack {
     attributes.key =
       attributes.key ?? `${this.vm.widgetSrc}-${element}-${this.vm.gIndex}`;
     delete attributes.dangerouslySetInnerHTML;
-    delete attributes.as;
     delete attributes.forwardedAs;
     const basicElement = styledComponent?.target || element;
+
+    if (attributes.as && !ApprovedTagsSimple[attributes.as]) {
+      delete attributes.as;
+    }
 
     if (basicElement === "img") {
       attributes.alt = attributes.alt ?? "not defined";

--- a/src/vm/vm.js
+++ b/src/vm/vm.js
@@ -428,11 +428,13 @@ class VmStack {
     attributes.key =
       attributes.key ?? `${this.vm.widgetSrc}-${element}-${this.vm.gIndex}`;
     delete attributes.dangerouslySetInnerHTML;
-    delete attributes.forwardedAs;
     const basicElement = styledComponent?.target || element;
 
     if (attributes.as && !ApprovedTagsSimple[attributes.as]) {
       delete attributes.as;
+    }
+    if (attributes.forwardedAs && !ApprovedTagsSimple[attributes.forwardedAs]) {
+      delete attributes.forwardedAs;
     }
 
     if (basicElement === "img") {


### PR DESCRIPTION
https://styled-components.com/docs/api#as-polymorphic-prop

Styled Components polymorphic `as` prop is really useful in certain cases (converting a `Button` component from a `<button>` to an `<a>` for example). Developers who are familiar with the library will be confused why the `as` prop doesn't work. It makes sense that we need to be careful with what tags we allow, but we can easily verify against our `ApprovedTagsSimple` list and remove the attribute if the tag isn't allowed.