### PR TITLE
Add alias for react and react-dom

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,11 @@ module.exports = function (env) {
           crypto: require.resolve("crypto-browserify"),
           stream: require.resolve("stream-browserify"),
         },
+        // Fix for using `yarn link "near-social-vm"`
+        alias: {
+          react: path.resolve(__dirname, "./node_modules/react"),
+          "react-dom": path.resolve(__dirname, "./node_modules/react-dom"),
+        },
       },
       plugins: [
         new webpack.EnvironmentPlugin({


### PR DESCRIPTION
This allows develop VM locally.

1) Execute `yarn link` in the VM repo
2) Execute `yarn link "near-social-vm"` in this repo.