### PR TITLE
Add account image endpoint

### DIFF
--- a/functions/[[accountId]]/widget/[[index]].js
+++ b/functions/[[accountId]]/widget/[[index]].js
@@ -1,4 +1,9 @@
-import { socialGet, imageToUrl, wrapImage } from "../../common";
+import {
+  socialGet,
+  imageToUrl,
+  wrapImage,
+  DefaultProfileImage,
+} from "../../common";
 
 class MetaTitleInjector {
   constructor({ title }) {

--- a/functions/[[accountId]]/widget/[[index]].js
+++ b/functions/[[accountId]]/widget/[[index]].js
@@ -1,4 +1,4 @@
-import { socialGet, viewCall } from "../../common";
+import { socialGet, imageToUrl, wrapImage } from "../../common";
 
 class MetaTitleInjector {
   constructor({ title }) {
@@ -81,88 +81,6 @@ function defaultData() {
   };
 }
 
-async function nftToImageUrl({ contractId, tokenId }) {
-  const [token, nftMetadata] = await Promise.all([
-    viewCall({
-      contractId,
-      method: "nft_token",
-      args: { token_id: tokenId },
-    }),
-    viewCall({
-      contractId,
-      method: "nft_metadata",
-      args: {},
-    }),
-  ]);
-
-  const tokenMetadata = token?.metadata || {};
-  const tokenMedia = tokenMetadata.media || "";
-
-  let imageUrl =
-    tokenMedia.startsWith("https://") ||
-    tokenMedia.startsWith("http://") ||
-    tokenMedia.startsWith("data:image")
-      ? tokenMedia
-      : nftMetadata.base_uri
-      ? `${nftMetadata.base_uri}/${tokenMedia}`
-      : tokenMedia.startsWith("Qm") || tokenMedia.startsWith("ba")
-      ? `https://ipfs.near.social/ipfs/${tokenMedia}`
-      : tokenMedia;
-
-  if (!tokenMedia && tokenMetadata.reference) {
-    const metadataUrl =
-      nftMetadata.base_uri === "https://arweave.net" &&
-      !tokenMetadata.reference.startsWith("https://")
-        ? `${nftMetadata.base_uri}/${tokenMetadata.reference}`
-        : tokenMetadata.reference.startsWith("https://") ||
-          tokenMetadata.reference.startsWith("http://")
-        ? tokenMetadata.reference
-        : tokenMetadata.reference.startsWith("ar://")
-        ? `https://arweave.net/${tokenMetadata.reference.split("//")[1]}`
-        : null;
-    if (metadataUrl) {
-      const res = await fetch(metadataUrl);
-      const json = await res.json();
-      imageUrl = json.media;
-    }
-  }
-
-  return imageUrl;
-}
-
-function wrapImage(url) {
-  return url ? `https://i.near.social/large/${url}` : null;
-}
-
-async function internalImageToUrl(env, image) {
-  if (image?.url) {
-    return image.url;
-  } else if (image?.ipfs_cid) {
-    return `https://ipfs.near.social/ipfs/${image.ipfs_cid}`;
-  } else if (image?.nft) {
-    try {
-      const { contractId, tokenId } = image.nft;
-      const NftKV = env.NftKV;
-
-      let imageUrl = await NftKV.get(`${contractId}/${tokenId}`);
-      if (!imageUrl) {
-        imageUrl = await nftToImageUrl({ contractId, tokenId });
-        if (imageUrl) {
-          await NftKV.put(`${contractId}/${tokenId}`, imageUrl);
-        }
-      }
-      return imageUrl;
-    } catch (e) {
-      console.log(e);
-    }
-  }
-  return null;
-}
-
-async function imageToUrl(env, image) {
-  return wrapImage(await internalImageToUrl(env, image));
-}
-
 async function postData(env, url, data, isPost) {
   const accountId = url.searchParams.get("accountId");
   const blockHeight = url.searchParams.get("blockHeight");
@@ -198,11 +116,7 @@ async function profileData(env, url, data) {
   data.description =
     profile?.description || `Profile of ${accountId} on Near Social`;
   data.image = await imageToUrl(env, profile?.image);
-  data.authorImage =
-    data.image ||
-    wrapImage(
-      "https://ipfs.near.social/ipfs/bafkreibmiy4ozblcgv3fm3gc6q62s55em33vconbavfd2ekkuliznaq3zm"
-    );
+  data.authorImage = data.image || wrapImage(DefaultProfileImage);
   data.title = name
     ? `${name} (${accountId}) | Near Social`
     : `${accountId} | Near Social`;

--- a/functions/magic/img/account/[index].js
+++ b/functions/magic/img/account/[index].js
@@ -16,5 +16,9 @@ export async function onRequest({ request, next, env }) {
   const destinationURL =
     (await internalImageToUrl(env, image)) || DefaultProfileImage;
 
-  return new Response(destinationURL);
+  return new Response(destinationURL, {
+    headers: {
+      "content-type": "text/plain;charset=UTF-8",
+    },
+  });
 }

--- a/functions/magic/img/account/[index].js
+++ b/functions/magic/img/account/[index].js
@@ -16,5 +16,5 @@ export async function onRequest({ request, next, env }) {
   const destinationURL =
     (await internalImageToUrl(env, image)) || DefaultProfileImage;
 
-  return Response.redirect(destinationURL, 301);
+  return await fetch(destinationURL);
 }

--- a/functions/magic/img/account/[index].js
+++ b/functions/magic/img/account/[index].js
@@ -16,5 +16,5 @@ export async function onRequest({ request, next, env }) {
   const destinationURL =
     (await internalImageToUrl(env, image)) || DefaultProfileImage;
 
-  return await fetch(destinationURL);
+  return new Response(destinationURL);
 }

--- a/functions/magic/img/account/[index].js
+++ b/functions/magic/img/account/[index].js
@@ -1,0 +1,20 @@
+import {
+  DefaultProfileImage,
+  internalImageToUrl,
+  socialGet,
+} from "../../../common";
+
+export async function onRequest({ request, next, env }) {
+  const url = new URL(request.url);
+  const parts = url.pathname.split("/");
+  if (parts.length !== 5) {
+    return next();
+  }
+  const accountId = parts[4];
+  const image = await socialGet(`${accountId}/profile/image/**`);
+
+  const destinationURL =
+    (await internalImageToUrl(env, image)) || DefaultProfileImage;
+
+  return Response.redirect(destinationURL, 301);
+}

--- a/functions/magic/img/nft/[[index]].js
+++ b/functions/magic/img/nft/[[index]].js
@@ -1,0 +1,26 @@
+import { internalImageToUrl } from "../../../common";
+
+export async function onRequest({ request, next, env }) {
+  const url = new URL(request.url);
+  const parts = url.pathname.split("/");
+  if (parts.length !== 6) {
+    return next();
+  }
+  const contractId = parts[4];
+  const tokenId = parts[5];
+
+  const destinationURL = await internalImageToUrl(env, {
+    nft: {
+      contractId,
+      tokenId,
+    },
+  });
+
+  return destinationURL
+    ? new Response(destinationURL, {
+        headers: {
+          "content-type": "text/plain;charset=UTF-8",
+        },
+      })
+    : next();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8532,9 +8532,9 @@ near-seed-phrase@^0.2.0:
     near-hd-key "^1.2.1"
     tweetnacl "^1.0.2"
 
-"near-social-vm@git+https://github.com/NearSocial/VM.git#2.2.3":
-  version "2.2.3"
-  resolved "git+https://github.com/NearSocial/VM.git#381ddbdc8ef5bde7975bebe8f640c1a5f9d85b94"
+"near-social-vm@git+https://github.com/NearSocial/VM.git#dev":
+  version "2.2.4"
+  resolved "git+https://github.com/NearSocial/VM.git#186bdea1d7d998e6dd836f54d974960ccaa312c8"
   dependencies:
     "@braintree/sanitize-url" "6.0.0"
     "@radix-ui/react-accordion" "^1.1.1"


### PR DESCRIPTION
Expose 2 endpoints:
- `/magic/img/account/[accountId]` to resolve image of the account to the URL
- `/magic/img/nft/[contractId]/[tokenId]` to resolve the image of the NFT to the URL
