### PR TITLE
add contract connection if detecting redirect from wallet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -143,6 +143,18 @@ function App(props) {
     );
   }, [account]);
 
+  useEffect(() => {
+    const addContractConnection = async () => {
+      const wallet = await (await near.selector).wallet();
+      const queryParams = new URLSearchParams(window.location.search);
+      if(queryParams.has('transactionHashes')) {
+        // if detecting redirect from wallet, add contract connection to prevent further wallet confirmations
+        // TODO: check what contract that was actually invoked instead of the hardcoding below ( which is just a PoC )
+        wallet.addContractConnection('devgovgigs.petersalomonsen.near', []);
+      }      
+    }
+    addContractConnection();
+  }, [near]);
   const passProps = {
     refreshAllowance: () => refreshAllowance(),
     setWidgetSrc,


### PR DESCRIPTION
in case of a redirection from the wallet, invoke `addContractConnection` on wallet to add a function access key to avoid further wallet confirmations.

depends on: https://github.com/near/wallet-selector/pull/887