### PR TITLE
QR Sign In for Mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "near-social-vm": "git+https://github.com/NearSocial/VM.git#2.4.2",
     "near-social-vm-types": "^1.0.0",
     "prettier": "^2.7.1",
+    "qrcode.react": "^3.1.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.5.0",
     "react-bootstrap-typeahead": "^6.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -31,6 +31,7 @@ import Big from "big.js";
 import { NavigationWrapper } from "./components/navigation/NavigationWrapper";
 import { NetworkId, Widgets } from "./data/widgets";
 import { useEthersProviderContext } from "./data/web3";
+import SignInPage from "./pages/SignInPage";
 
 export const refreshAllowanceObj = {};
 const documentationHref = "https://social.near-docs.io/";
@@ -67,7 +68,7 @@ function App(props) {
               gas: "300000000000000",
               bundle: false,
             }),
-              setupNightly(),
+            setupNightly(),
           ],
         }),
         customElements: {
@@ -164,6 +165,10 @@ function App(props) {
       <EthersProviderContext.Provider value={ethersProviderContext}>
         <Router basename={process.env.PUBLIC_URL}>
           <Switch>
+            <Route path={"/signin"}>
+              <NavigationWrapper {...passProps} />
+              <SignInPage {...passProps} />
+            </Route>
             <Route path={"/embed/:widgetSrc*"}>
               <EmbedPage {...passProps} />
             </Route>

--- a/src/components/icons/QR.js
+++ b/src/components/icons/QR.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+export function QR() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 16 16"
+      strokeWidth="0.5"
+    >
+      <path d="M2 2h2v2H2V2Z" />
+      <path d="M6 0v6H0V0h6ZM5 1H1v4h4V1ZM4 12H2v2h2v-2Z" />
+      <path d="M6 10v6H0v-6h6Zm-5 1v4h4v-4H1Zm11-9h2v2h-2V2Z" />
+      <path d="M10 0v6h6V0h-6Zm5 1v4h-4V1h4ZM8 1V0h1v2H8v2H7V1h1Zm0 5V4h1v2H8ZM6 8V7h1V6h1v2h1V7h5v1h-4v1H7V8H6Zm0 0v1H2V8H1v1H0V7h3v1h3Zm10 1h-1V7h1v2Zm-1 0h-1v2h2v-1h-1V9Zm-4 0h2v1h-1v1h-1V9Zm2 3v-1h-1v1h-1v1H9v1h3v-2h1Zm0 0h3v1h-2v1h-1v-2Zm-4-1v1h1v-2H7v1h2Z" />
+      <path d="M7 12h1v3h4v1H7v-4Zm9 2v2h-3v-1h2v-1h1Z" />
+    </svg>
+  );
+}

--- a/src/components/navigation/MobileQRModal.js
+++ b/src/components/navigation/MobileQRModal.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from "react";
+import Modal from "react-bootstrap/Modal";
+import { useAccount } from "near-social-vm";
+import { QRCodeSVG } from "qrcode.react";
+import { NetworkId } from "../../data/widgets";
+import * as nearAPI from "near-api-js";
+
+export default function MobileQRModal(props) {
+  const account = useAccount();
+  const onHide = props.onHide;
+  const show = props.show;
+
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      const domain = new URL(window.location.href).origin;
+      const keyStore = new nearAPI.keyStores.BrowserLocalStorageKeyStore();
+      const keyPair = await keyStore.getKey(NetworkId, account.accountId);
+      return `${domain}/signin#?a=${account.accountId}&k=${keyPair.toString()}`;
+    })().then(setUrl);
+  }, [account]);
+
+  return (
+    <Modal centered show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Scan QR to sign in on another device</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="w-100">
+          <QRCodeSVG value={url} size="100%" />
+        </div>
+        <div>
+          <small className="text-muted">
+            Don't share this QR with other people. It's only for you.
+          </small>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <button className="btn btn-secondary" onClick={onHide}>
+          Close
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/components/navigation/desktop/UserDropdown.js
+++ b/src/components/navigation/desktop/UserDropdown.js
@@ -8,6 +8,8 @@ import { NavLink } from "react-router-dom";
 import PretendModal from "../PretendModal";
 import { Pretend } from "../../icons/Pretend";
 import { StopPretending } from "../../icons/StopPretending";
+import { QR } from "../../icons/QR";
+import MobileQRModal from "../MobileQRModal";
 
 const StyledDropdown = styled.div`
   button,
@@ -101,6 +103,7 @@ export function UserDropdown(props) {
   }, [near]);
 
   const [showPretendModal, setShowPretendModal] = React.useState(false);
+  const [showMobileQR, setShowMobileQR] = React.useState(false);
 
   return (
     <>
@@ -155,7 +158,7 @@ export function UserDropdown(props) {
             </button>
           </li>
           {account.pretendAccountId ? (
-            <li>
+            <li key="pretend">
               <button
                 className="dropdown-item"
                 type="button"
@@ -167,7 +170,7 @@ export function UserDropdown(props) {
               </button>
             </li>
           ) : (
-            <li>
+            <li key="stop-pretend">
               <button
                 className="dropdown-item"
                 type="button"
@@ -178,6 +181,16 @@ export function UserDropdown(props) {
               </button>
             </li>
           )}
+          <li>
+            <button
+              className="dropdown-item"
+              type="button"
+              onClick={() => setShowMobileQR(true)}
+            >
+              <QR />
+              Show QR for mobile signin
+            </button>
+          </li>
           <li>
             <button
               className="dropdown-item"
@@ -194,6 +207,10 @@ export function UserDropdown(props) {
         show={showPretendModal}
         onHide={() => setShowPretendModal(false)}
         widgets={props.widgets}
+      />
+      <MobileQRModal
+        show={showMobileQR}
+        onHide={() => setShowMobileQR(false)}
       />
     </>
   );

--- a/src/components/navigation/desktop/UserDropdown.js
+++ b/src/components/navigation/desktop/UserDropdown.js
@@ -188,7 +188,7 @@ export function UserDropdown(props) {
               onClick={() => setShowMobileQR(true)}
             >
               <QR />
-              Show QR for mobile signin
+              Mobile Sign-in QR
             </button>
           </li>
           <li>

--- a/src/data/widgets.js
+++ b/src/data/widgets.js
@@ -14,6 +14,7 @@ const TestnetWidgets = {
   profileImage: "eugenethedream/widget/ProfileImage",
   profilePage: "eugenethedream/widget/Profile",
   profileName: "eugenethedream/widget/ProfileName",
+  profileInlineBlock: "eugenethedream/widget/Profile",
   notificationButton: "eugenethedream/widget/NotificationButton",
 };
 

--- a/src/pages/SignInPage.js
+++ b/src/pages/SignInPage.js
@@ -1,0 +1,89 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useAccount } from "near-social-vm";
+import { Widget } from "../../../VM";
+import { useHistory } from "react-router-dom";
+import * as nearAPI from "near-api-js";
+import { NetworkId } from "../data/widgets";
+import ls from "local-storage";
+
+const WalletSelectorDefaultValues = {
+  "near-wallet-selector:selectedWalletId": "near-wallet",
+  "near-wallet-selector:recentlySignedInWallets": ["near-wallet"],
+  "near-wallet-selector:contract": {
+    contractId: NetworkId === "testnet" ? "v1.social08.testnet" : "social.near",
+    methodNames: [],
+  },
+};
+
+const WalletSelectorAuthKey = "near_app_wallet_auth_key";
+
+export default function SignInPage(props) {
+  const [params, setParams] = useState({});
+  const account = useAccount();
+  const history = useHistory();
+
+  useEffect(() => {
+    const currentUrl = window.location.href;
+
+    if (currentUrl.includes("#")) {
+      const path = currentUrl.split("#")[1];
+      const query = new URLSearchParams(path);
+      setParams({
+        accountId: query.get("a"),
+        privateKey: query.get("k"),
+      });
+    }
+  }, []);
+
+  const localSignIn = useCallback(async () => {
+    const keyStore = new nearAPI.keyStores.BrowserLocalStorageKeyStore();
+    const keyPair = nearAPI.KeyPair.fromString(params.privateKey);
+    await keyStore.setKey(NetworkId, params.accountId, keyPair);
+    Object.entries(WalletSelectorDefaultValues).forEach(([key, value]) => {
+      ls.set(key, value);
+    });
+    ls.set(WalletSelectorAuthKey, {
+      accountId: params.accountId,
+      allKeys: [keyPair.publicKey.toString()],
+    });
+    window.location.href = "/";
+  }, [params.accountId, params.privateKey]);
+
+  return (
+    <div className="container-xl">
+      <div className="row">
+        <div
+          className="d-inline-block position-relative overflow-hidden"
+          style={{
+            "--body-top-padding": "24px",
+            paddingTop: "var(--body-top-padding)",
+          }}
+        >
+          <h3>Sign in as</h3>
+          <div className="mt-2">
+            <Widget
+              src={props.widgets.profileInlineBlock}
+              props={{ accountId: params.accountId }}
+            />
+          </div>
+          <div className="mt-4 d-flex gap-2">
+            <button
+              className="btn btn-lg w-100 btn-success"
+              onClick={() => localSignIn()}
+            >
+              Sign In
+            </button>
+            <button
+              className="btn btn-lg w-100 btn-danger"
+              onClick={() => {
+                history.push("/");
+              }}
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SignInPage.js
+++ b/src/pages/SignInPage.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { useAccount } from "near-social-vm";
-import { Widget } from "../../../VM";
+import { Widget } from "near-social-vm";
 import { useHistory } from "react-router-dom";
 import * as nearAPI from "near-api-js";
 import { NetworkId } from "../data/widgets";
@@ -19,7 +18,6 @@ const WalletSelectorAuthKey = "near_app_wallet_auth_key";
 
 export default function SignInPage(props) {
   const [params, setParams] = useState({});
-  const account = useAccount();
   const history = useHistory();
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8777,6 +8777,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
+qrcode.react@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/qrcode.react/-/qrcode.react-3.1.0.tgz#5c91ddc0340f768316fbdb8fff2765134c2aecd8"
+  integrity sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==
+
 qrcode@1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.4.4.tgz#f0c43568a7e7510a55efc3b88d9602f71963ea83"


### PR DESCRIPTION
Ability to display a QR code on desktop version with the local secret key. When the QR is scanned on mobile, it redirects to a sign in prompt. No full access key required.

Demo showing the QR code

https://github.com/NearSocial/viewer/assets/470453/36d82cba-a516-4594-a30b-07538e2d234c

Sign in flow

https://github.com/NearSocial/viewer/assets/470453/b7bc09e4-6bfa-49c1-9e31-8b7ed0e4ad86

