### PR TITLE
Remove overflow on view page

### DIFF
--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -767,7 +767,7 @@ export default function EditorPage(props) {
             >
               <div className="container">
                 <div className="row">
-                  <div className="d-inline-block position-relative overflow-hidden">
+                  <div className="position-relative">
                     {renderCode ? (
                       <Widget
                         key={`${previewKey}-${jpath}`}
@@ -789,7 +789,7 @@ export default function EditorPage(props) {
             >
               <div className="container">
                 <div className="row">
-                  <div className="d-inline-block position-relative overflow-hidden">
+                  <div className="position-relative">
                     <Widget
                       key={`metadata-${jpath}`}
                       src={props.widgets.widgetMetadata}

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -41,7 +41,7 @@ export default function ViewPage(props) {
     <div className="container-xl">
       <div className="row">
         <div
-          className="d-inline-block position-relative overflow-hidden"
+          className="position-relative"
           style={{
             "--body-top-padding": "24px",
             paddingTop: "var(--body-top-padding)",


### PR DESCRIPTION
It would allow main widget to overflow into the menu as well to the sides