### PR TITLE
feat: add fork data to metadata in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,32 @@ A framework for reusable components to render and modify SocialDB by Near Social
 ## Setup & Development
 
 Initialize repo:
+
 ```
 yarn
 ```
 
 Start development version:
+
 ```
 yarn start
 ```
 
 ## Widget example
 
-Profile view 
+Profile view
 
 ```jsx
 let accountId = props.accountId || "eugenethedream";
 let profile = socialGetr(`${accountId}/profile`);
 
-(
-  <div>
-    <img src={profile.image.url}/>
-    <span>{profile.name}</span> <span>(@{accountId})</span>
-  </div>
-);
+<div>
+  <img src={profile.image.url} />
+  <span>{profile.name}</span> <span>(@{accountId})</span>
+</div>;
 ```
 
-
-Profile editor 
+Profile editor
 
 ```jsx
 let accountId = context.accountId;
@@ -80,5 +79,4 @@ return (
     </div>
   </div>
 );
-
 ```

--- a/public/index.html
+++ b/public/index.html
@@ -12,15 +12,18 @@
     -->
     <link rel="manifest" href="/manifest.json" />
     <meta
-        name="description"
-        content="Decentralized Customizable Social Network on NEAR Protocol"
+      name="description"
+      content="Decentralized Customizable Social Network on NEAR Protocol"
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@NearSocial_">
-    <meta property="og:image" content="https://near.social/logo.png">
-    <meta property="og:type" content="website">
+    <meta name="twitter:site" content="@NearSocial_" />
+    <meta property="og:image" content="https://near.social/logo.png" />
+    <meta property="og:type" content="website" />
     <meta property="og:title" content="Near Social" />
-    <meta property="og:description" content="Decentralized Customizable Social Network on NEAR Protocol" />
+    <meta
+      property="og:description"
+      content="Decentralized Customizable Social Network on NEAR Protocol"
+    />
     <title>Near Social</title>
   </head>
   <body>

--- a/src/App.scss
+++ b/src/App.scss
@@ -4,7 +4,8 @@ body {
   overflow-y: scroll;
 }
 
-body, html {
+body,
+html {
   -webkit-font-smoothing: antialiased;
 }
 
@@ -12,10 +13,11 @@ body, html {
   cursor: pointer;
 }
 
-.btn-success, .btn-primary {
+.btn-success,
+.btn-primary {
   .text-muted {
     color: #fff !important;
-  };
+  }
 }
 
 .outline-none {
@@ -33,7 +35,7 @@ a {
 }
 
 .sidebar-items {
-  &> div {
+  & > div {
     border-right: 1px solid #e5e5e5;
     text-align: center;
     min-height: 4rem;
@@ -41,7 +43,7 @@ a {
     display: flex;
   }
 
-  &> div:not(.apps) {
+  & > div:not(.apps) {
     min-width: 4rem;
     align-items: center !important;
     justify-content: center !important;

--- a/src/components/Editor/FileTab.js
+++ b/src/components/Editor/FileTab.js
@@ -1,25 +1,26 @@
-import { Nav } from "react-bootstrap";
-import React, { useEffect, useState } from "react";
-import { useAccountId, useCache, useNear } from "near-social-vm";
+import { Nav } from 'react-bootstrap';
+import React, { useEffect, useState } from 'react';
+import { useAccountId, useCache, useNear } from 'near-social-vm';
 
 export const Filetype = {
-  Widget: "widget",
-  Module: "module",
+  Widget: 'widget',
+  Module: 'module',
 };
 
 export const StorageDomain = {
-  page: "editor",
+  page: 'editor',
 };
 
 export const StorageType = {
-  Code: "code",
-  Files: "files",
+  Code: 'code',
+  Files: 'files',
+  forkDetails: 'forkDetails',
 };
 
 export function toPath(type, nameOrPath) {
   const name =
-    nameOrPath.indexOf("/") >= 0
-      ? nameOrPath.split("/").slice(2).join("/")
+    nameOrPath.indexOf('/') >= 0
+      ? nameOrPath.split('/').slice(2).join('/')
       : nameOrPath;
   return { type, name };
 }
@@ -96,7 +97,7 @@ export function FileTab(props) {
         )}
         <button
           className={`btn btn-sm border-0 py-0 px-1 ms-1 rounded-circle ${
-            active ? "btn-outline-light" : "btn-outline-secondary"
+            active ? 'btn-outline-light' : 'btn-outline-secondary'
           }`}
           onClick={(e) => {
             e.preventDefault();

--- a/src/components/Editor/FileTab.js
+++ b/src/components/Editor/FileTab.js
@@ -42,6 +42,7 @@ export function FileTab(props) {
   const accountId = useAccountId();
   const [localCode, setLocalCode] = useState(null);
   const [chainCode, setChainCode] = useState(null);
+  const [tabWidgetSrc, setTabWidgetSrc] = useState(null);
   const [saved, setSaved] = useState(false);
 
   const jp = JSON.stringify(p);

--- a/src/components/Editor/FileTab.js
+++ b/src/components/Editor/FileTab.js
@@ -1,26 +1,26 @@
-import { Nav } from 'react-bootstrap';
-import React, { useEffect, useState } from 'react';
-import { useAccountId, useCache, useNear } from 'near-social-vm';
+import { Nav } from "react-bootstrap";
+import React, { useEffect, useState } from "react";
+import { useAccountId, useCache, useNear } from "near-social-vm";
 
 export const Filetype = {
-  Widget: 'widget',
-  Module: 'module',
+  Widget: "widget",
+  Module: "module",
 };
 
 export const StorageDomain = {
-  page: 'editor',
+  page: "editor",
 };
 
 export const StorageType = {
-  Code: 'code',
-  Files: 'files',
-  forkDetails: 'forkDetails',
+  Code: "code",
+  Files: "files",
+  forkDetails: "forkDetails",
 };
 
 export function toPath(type, nameOrPath) {
   const name =
-    nameOrPath.indexOf('/') >= 0
-      ? nameOrPath.split('/').slice(2).join('/')
+    nameOrPath.indexOf("/") >= 0
+      ? nameOrPath.split("/").slice(2).join("/")
       : nameOrPath;
   return { type, name };
 }
@@ -98,7 +98,7 @@ export function FileTab(props) {
         )}
         <button
           className={`btn btn-sm border-0 py-0 px-1 ms-1 rounded-circle ${
-            active ? 'btn-outline-light' : 'btn-outline-secondary'
+            active ? "btn-outline-light" : "btn-outline-secondary"
           }`}
           onClick={(e) => {
             e.preventDefault();

--- a/src/components/Editor/OpenModal.js
+++ b/src/components/Editor/OpenModal.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import Modal from 'react-bootstrap/Modal';
+import React, { useState } from "react";
+import Modal from "react-bootstrap/Modal";
 
 export default function OpenModal(props) {
   const onHide = props.onHide;
@@ -7,7 +7,7 @@ export default function OpenModal(props) {
   const onNew = props.onNew;
   const show = props.show;
 
-  const [widgetSrc, setWidgetSrc] = useState('');
+  const [widgetSrc, setWidgetSrc] = useState("");
 
   return (
     <Modal centered scrollable show={show} onHide={onHide}>
@@ -24,7 +24,7 @@ export default function OpenModal(props) {
           type="text"
           value={widgetSrc}
           onChange={(e) =>
-            setWidgetSrc(e.target.value.replaceAll(/[^a-zA-Z0-9_.\-\/]/g, ''))
+            setWidgetSrc(e.target.value.replaceAll(/[^a-zA-Z0-9_.\-\/]/g, ""))
           }
         />
       </Modal.Body>
@@ -35,7 +35,7 @@ export default function OpenModal(props) {
           onClick={(e) => {
             e.preventDefault();
             onOpen(widgetSrc);
-            setWidgetSrc('');
+            setWidgetSrc("");
             onHide();
           }}
         >
@@ -43,11 +43,11 @@ export default function OpenModal(props) {
         </button>
         <button
           className="btn btn-outline-success"
-          disabled={widgetSrc && widgetSrc.indexOf('/') !== -1}
+          disabled={widgetSrc && widgetSrc.indexOf("/") !== -1}
           onClick={(e) => {
             e.preventDefault();
             onNew(widgetSrc);
-            setWidgetSrc('');
+            setWidgetSrc("");
             onHide();
           }}
         >

--- a/src/components/Editor/OpenModal.js
+++ b/src/components/Editor/OpenModal.js
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import Modal from "react-bootstrap/Modal";
+import React, { useState } from 'react';
+import Modal from 'react-bootstrap/Modal';
 
 export default function OpenModal(props) {
   const onHide = props.onHide;
@@ -7,7 +7,7 @@ export default function OpenModal(props) {
   const onNew = props.onNew;
   const show = props.show;
 
-  const [widgetSrc, setWidgetSrc] = useState("");
+  const [widgetSrc, setWidgetSrc] = useState('');
 
   return (
     <Modal centered scrollable show={show} onHide={onHide}>
@@ -24,7 +24,7 @@ export default function OpenModal(props) {
           type="text"
           value={widgetSrc}
           onChange={(e) =>
-            setWidgetSrc(e.target.value.replaceAll(/[^a-zA-Z0-9_.\-\/]/g, ""))
+            setWidgetSrc(e.target.value.replaceAll(/[^a-zA-Z0-9_.\-\/]/g, ''))
           }
         />
       </Modal.Body>
@@ -35,7 +35,7 @@ export default function OpenModal(props) {
           onClick={(e) => {
             e.preventDefault();
             onOpen(widgetSrc);
-            setWidgetSrc("");
+            setWidgetSrc('');
             onHide();
           }}
         >
@@ -43,11 +43,12 @@ export default function OpenModal(props) {
         </button>
         <button
           className="btn btn-outline-success"
-          disabled={widgetSrc && widgetSrc.indexOf("/") !== -1}
+          disabled={widgetSrc && widgetSrc.indexOf('/') !== -1}
           onClick={(e) => {
+            console.log('widgetSrc on press of Create New ln 48', widgetSrc);
             e.preventDefault();
             onNew(widgetSrc);
-            setWidgetSrc("");
+            setWidgetSrc('');
             onHide();
           }}
         >

--- a/src/components/Editor/OpenModal.js
+++ b/src/components/Editor/OpenModal.js
@@ -45,7 +45,6 @@ export default function OpenModal(props) {
           className="btn btn-outline-success"
           disabled={widgetSrc && widgetSrc.indexOf('/') !== -1}
           onClick={(e) => {
-            console.log('widgetSrc on press of Create New ln 48', widgetSrc);
             e.preventDefault();
             onNew(widgetSrc);
             setWidgetSrc('');

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,12 @@
 :root {
   --slate-dark-1: #151718;
-  --slate-dark-5: #2B2F31;
+  --slate-dark-5: #2b2f31;
   --slate-dark-6: #313538;
-  --slate-dark-8: #4C5155;
+  --slate-dark-8: #4c5155;
   --slate-dark-9: #697177;
-  --slate-dark-11: #9BA1A6;
-  --slate-dark-12: #ECEDEE;
-  --blue-light-9: #0091FF;
+  --slate-dark-11: #9ba1a6;
+  --slate-dark-12: #ecedee;
+  --blue-light-9: #0091ff;
 
   --font-weight-medium: 500;
   --font-weight-bold: 600;
@@ -16,4 +16,3 @@
   --account-center-position-top: 64px;
   --account-center-position-right: -10px;
 }
-

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -814,12 +814,6 @@ export default function EditorPage(props) {
                         Open Component
                       </a>
                     )}
-                    <button
-                      className="btn btn-outline-dark"
-                      onClick={deleteCache}
-                    >
-                      Delete Cache
-                    </button>
 
                     <div className="dropdown">
                       <button

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -177,7 +177,6 @@ export default function EditorPage(props) {
   );
 
   const deleteCache = useCallback(async () => {
-    
     try {
       const response = await cache.localStorageSet(
         StorageDomain,
@@ -187,7 +186,6 @@ export default function EditorPage(props) {
         },
         {}
       );
-      
     } catch {
       console.error(e);
     }
@@ -214,13 +212,7 @@ export default function EditorPage(props) {
       view: localWidgetSrc,
     });
 
-    
-
     if (localWidgetSrc) {
-      
-        'this is the widgetsource and firing on ln 204',
-        localWidgetSrc
-      );
       checkForkDetails(localWidgetSrc);
       /*
        1. check if there are any forkDetails in localStorage
@@ -302,8 +294,6 @@ export default function EditorPage(props) {
 
   const openFile = useCallback(
     (path, code) => {
-      
-      
       setPath(path);
       addToFiles(path);
       setMetadata(undefined);
@@ -319,8 +309,6 @@ export default function EditorPage(props) {
             type: StorageType.Code,
           })
           .then(({ code }) => {
-            
-            
             updateCode(path, code);
             checkForkDetails(path);
           })
@@ -349,12 +337,8 @@ export default function EditorPage(props) {
           : `${accountId}/widget/${nameOrPath}`;
 
       setLocalWidgetSrc(widgetSrc);
-      
-      
 
       const c = () => {
-        
-        
         const code = cache.socialGet(
           near,
           widgetSrc,

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -176,21 +176,6 @@ export default function EditorPage(props) {
     [setForkDetails]
   );
 
-  const deleteCache = useCallback(async () => {
-    try {
-      const response = await cache.localStorageSet(
-        StorageDomain,
-        {
-          path,
-          type: StorageType.forkDetails,
-        },
-        {}
-      );
-    } catch {
-      console.error(e);
-    }
-  }, [path]);
-
   useEffect(() => {
     if (forkDetails) {
       setMetadata({
@@ -199,6 +184,13 @@ export default function EditorPage(props) {
       });
     }
   }, [forkDetails]);
+
+  // prevent metadata from being overwritten by empty object
+  useEffect(() => {
+    if (JSON.stringify(metadata) === '{}') {
+      setMetadata(undefined);
+    }
+  }, [metadata]);
 
   useEffect(() => {
     if (path || (widgetSrc && path)) {
@@ -814,12 +806,7 @@ export default function EditorPage(props) {
                         Open Component
                       </a>
                     )}
-                    <button
-                      className="btn btn-outline-dark"
-                      onClick={deleteCache}
-                    >
-                      Delete Cache
-                    </button>
+
                     <div className="dropdown">
                       <button
                         className="btn btn-outline-secondary flex-shrink-1"

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -140,6 +140,8 @@ export default function EditorPage(props) {
       if (response?.fork_of) {
         setForkDetails(response);
         return response;
+      } else if (JSON.stringify(response) === "{}") {
+        setForkDetails(undefined);
       } else if (localWidgetSrc && JSON.stringify(response) !== "{}") {
         getForkDetails(path);
       }
@@ -342,7 +344,7 @@ export default function EditorPage(props) {
 
       c();
     },
-    [accountId, openFile, toPath, near, cache, localWidgetSrc]
+    [accountId, openFile, toPath, near, cache, setLocalWidgetSrc]
   );
 
   const generateNewName = useCallback(
@@ -378,7 +380,7 @@ export default function EditorPage(props) {
         const newPath = toPath(path.type, newName);
         const jNewPath = JSON.stringify(newPath);
         const jPath = JSON.stringify(path);
-        forkDetails?.fork_of
+        forkDetails?.fork_of && !path.name.includes("New-Draft")
           ? await storeForkDetails(newPath, forkDetails.fork_of)
           : storeForkDetails(newPath, null);
         setFiles((files) => {

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -451,7 +451,9 @@ export default function EditorPage(props) {
         });
         updateCode(path, formattedCode);
         checkForkDetails(path);
-      } catch (e) {}
+      } catch (e) {
+        console.error(e);
+      }
     },
     [updateCode]
   );
@@ -461,7 +463,9 @@ export default function EditorPage(props) {
       try {
         const formattedProps = JSON.stringify(JSON.parse(props), null, 2);
         setWidgetProps(formattedProps);
-      } catch (e) {}
+      } catch (e) {
+        console.error(e);
+      }
     },
     [setWidgetProps]
   );

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -1,47 +1,47 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import ls from 'local-storage';
-import prettier, { check } from 'prettier';
-import parserBabel from 'prettier/parser-babel';
-import { useHistory, useParams } from 'react-router-dom';
-import Editor, { useMonaco } from '@monaco-editor/react';
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import ls from "local-storage";
+import prettier, { check } from "prettier";
+import parserBabel from "prettier/parser-babel";
+import { useHistory, useParams } from "react-router-dom";
+import Editor, { useMonaco } from "@monaco-editor/react";
 import {
   Widget,
   useCache,
   useNear,
   CommitButton,
   useAccountId,
-} from 'near-social-vm';
-import { Nav, OverlayTrigger, Tooltip } from 'react-bootstrap';
-import RenameModal from '../components/Editor/RenameModal';
-import OpenModal from '../components/Editor/OpenModal';
+} from "near-social-vm";
+import { Nav, OverlayTrigger, Tooltip } from "react-bootstrap";
+import RenameModal from "../components/Editor/RenameModal";
+import OpenModal from "../components/Editor/OpenModal";
 import {
   FileTab,
   Filetype,
   StorageDomain,
   StorageType,
   toPath,
-} from '../components/Editor/FileTab';
-import { useHashRouterLegacy } from '../hooks/useHashRouterLegacy';
-import vmTypesDeclaration from 'raw-loader!near-social-vm-types';
-import styled from 'styled-components';
+} from "../components/Editor/FileTab";
+import { useHashRouterLegacy } from "../hooks/useHashRouterLegacy";
+import vmTypesDeclaration from "raw-loader!near-social-vm-types";
+import styled from "styled-components";
 
-const LsKey = 'social.near:v01:';
-const EditorLayoutKey = LsKey + 'editorLayout:';
-const WidgetPropsKey = LsKey + 'widgetProps:';
-const EditorUncommittedPreviewsKey = LsKey + 'editorUncommittedPreviews:';
+const LsKey = "social.near:v01:";
+const EditorLayoutKey = LsKey + "editorLayout:";
+const WidgetPropsKey = LsKey + "widgetProps:";
+const EditorUncommittedPreviewsKey = LsKey + "editorUncommittedPreviews:";
 
-const DefaultEditorCode = 'return <div>Hello World</div>;';
+const DefaultEditorCode = "return <div>Hello World</div>;";
 
 const Tab = {
-  Editor: 'Editor',
-  Props: 'Props',
-  Metadata: 'Metadata',
-  Widget: 'Widget',
+  Editor: "Editor",
+  Props: "Props",
+  Metadata: "Metadata",
+  Widget: "Widget",
 };
 
 const Layout = {
-  Tabs: 'Tabs',
-  Split: 'Split',
+  Tabs: "Tabs",
+  Split: "Split",
 };
 
 export default function EditorPage(props) {
@@ -66,7 +66,7 @@ export default function EditorPage(props) {
 
   const [renderCode, setRenderCode] = useState(code);
   const [widgetProps, setWidgetProps] = useState(
-    ls.get(WidgetPropsKey) || '{}'
+    ls.get(WidgetPropsKey) || "{}"
   );
   const [parsedWidgetProps, setParsedWidgetProps] = useState({});
   const [propsError, setPropsError] = useState(null);
@@ -80,7 +80,7 @@ export default function EditorPage(props) {
   const [layout, setLayoutState] = useState(
     ls.get(EditorLayoutKey) || Layout.Split
   );
-  const [previewKey, setPreviewKey] = useState('');
+  const [previewKey, setPreviewKey] = useState("");
 
   const monaco = useMonaco();
 
@@ -105,21 +105,21 @@ export default function EditorPage(props) {
     try {
       if (localWidgetSrc) {
         const res = await fetch(`${near.config.apiUrl}/keys`, {
-          method: 'POST',
+          method: "POST",
           body: JSON.stringify({
             keys: [localWidgetSrc],
-            options: { return_type: 'BlockHeight' },
+            options: { return_type: "BlockHeight" },
           }),
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
         });
 
         const sourceWidget = await res.json();
 
-        const srcArr = localWidgetSrc.split('/');
+        const srcArr = localWidgetSrc.split("/");
         const forkOf =
-          localWidgetSrc + '@' + sourceWidget[srcArr[0]][srcArr[1]][srcArr[2]];
+          localWidgetSrc + "@" + sourceWidget[srcArr[0]][srcArr[1]][srcArr[2]];
 
         storeForkDetails(path, forkOf);
         return;
@@ -140,7 +140,7 @@ export default function EditorPage(props) {
       if (response?.fork_of) {
         setForkDetails(response);
         return response;
-      } else if (localWidgetSrc && JSON.stringify(response) !== '{}') {
+      } else if (localWidgetSrc && JSON.stringify(response) !== "{}") {
         getForkDetails(path);
       }
     } catch (e) {
@@ -187,7 +187,7 @@ export default function EditorPage(props) {
 
   // prevent metadata from being overwritten by empty object
   useEffect(() => {
-    if (JSON.stringify(metadata) === '{}') {
+    if (JSON.stringify(metadata) === "{}") {
       setMetadata(undefined);
     }
   }, [metadata]);
@@ -318,7 +318,7 @@ export default function EditorPage(props) {
         return;
       }
       const widgetSrc =
-        nameOrPath.indexOf('/') >= 0
+        nameOrPath.indexOf("/") >= 0
           ? nameOrPath
           : `${accountId}/widget/${nameOrPath}`;
 
@@ -334,7 +334,7 @@ export default function EditorPage(props) {
           c
         );
         if (code) {
-          const name = widgetSrc.split('/').slice(2).join('/');
+          const name = widgetSrc.split("/").slice(2).join("/");
 
           openFile(toPath(Filetype.Widget, widgetSrc), code);
         }
@@ -364,7 +364,7 @@ export default function EditorPage(props) {
     (type) => {
       setForkDetails(undefined);
       setMetadata(undefined);
-      setLocalWidgetSrc('');
+      setLocalWidgetSrc("");
       const path = generateNewName(type);
 
       openFile(path, DefaultEditorCode);
@@ -427,7 +427,7 @@ export default function EditorPage(props) {
       return;
     }
     if (widgetSrc) {
-      if (widgetSrc === 'new') {
+      if (widgetSrc === "new") {
         createFile(Filetype.Widget);
       } else {
         loadFile(widgetSrc);
@@ -446,7 +446,7 @@ export default function EditorPage(props) {
     (path, code) => {
       try {
         const formattedCode = prettier.format(code, {
-          parser: 'babel',
+          parser: "babel",
           plugins: [parserBabel],
         });
         updateCode(path, formattedCode);
@@ -487,7 +487,7 @@ export default function EditorPage(props) {
     [openFile, createFile]
   );
 
-  const layoutClass = layout === Layout.Split ? 'col-lg-6' : '';
+  const layoutClass = layout === Layout.Split ? "col-lg-6" : "";
 
   const onLayoutChange = useCallback(
     (e) => {
@@ -540,7 +540,7 @@ export default function EditorPage(props) {
       data={{
         widget: {
           [widgetName]: {
-            '': code,
+            "": code,
             metadata,
           },
         },
@@ -687,7 +687,7 @@ export default function EditorPage(props) {
               checked={layout === Layout.Tabs}
               onChange={onLayoutChange}
               value={Layout.Tabs}
-              title={'Set layout to Tabs mode'}
+              title={"Set layout to Tabs mode"}
             />
             <label className="btn btn-outline-secondary" htmlFor="layout-tabs">
               <i className="bi bi-square" />
@@ -701,7 +701,7 @@ export default function EditorPage(props) {
               autoComplete="off"
               checked={layout === Layout.Split}
               value={Layout.Split}
-              title={'Set layout to Split mode'}
+              title={"Set layout to Split mode"}
               onChange={onLayoutChange}
             />
             <label className="btn btn-outline-secondary" htmlFor="layout-split">
@@ -715,7 +715,7 @@ export default function EditorPage(props) {
               <ul className={`nav nav-tabs mb-2`}>
                 <li className="nav-item">
                   <button
-                    className={`nav-link ${tab === Tab.Editor ? 'active' : ''}`}
+                    className={`nav-link ${tab === Tab.Editor ? "active" : ""}`}
                     aria-current="page"
                     onClick={() => setTab(Tab.Editor)}
                   >
@@ -724,7 +724,7 @@ export default function EditorPage(props) {
                 </li>
                 <li className="nav-item">
                   <button
-                    className={`nav-link ${tab === Tab.Props ? 'active' : ''}`}
+                    className={`nav-link ${tab === Tab.Props ? "active" : ""}`}
                     aria-current="page"
                     onClick={() => setTab(Tab.Props)}
                   >
@@ -735,7 +735,7 @@ export default function EditorPage(props) {
                   <li className="nav-item">
                     <button
                       className={`nav-link ${
-                        tab === Tab.Metadata ? 'active' : ''
+                        tab === Tab.Metadata ? "active" : ""
                       }`}
                       aria-current="page"
                       onClick={() => setTab(Tab.Metadata)}
@@ -748,7 +748,7 @@ export default function EditorPage(props) {
                   <li className="nav-item">
                     <button
                       className={`nav-link ${
-                        tab === Tab.Widget ? 'active' : ''
+                        tab === Tab.Widget ? "active" : ""
                       }`}
                       aria-current="page"
                       onClick={() => {
@@ -762,10 +762,10 @@ export default function EditorPage(props) {
                 )}
               </ul>
 
-              <div className={`${tab === Tab.Editor ? '' : 'visually-hidden'}`}>
+              <div className={`${tab === Tab.Editor ? "" : "visually-hidden"}`}>
                 <div
                   className="d-flex flex-column overflow-hidden"
-                  style={{ height: '80vh' }}
+                  style={{ height: "80vh" }}
                 >
                   <div
                     className="mb-2 flex-grow-1 border"
@@ -799,7 +799,7 @@ export default function EditorPage(props) {
                     {!path?.unnamed && commitButton}
                     <button
                       className={`btn ${
-                        path?.unnamed ? 'btn-primary' : 'btn-outline-secondary'
+                        path?.unnamed ? "btn-primary" : "btn-outline-secondary"
                       }`}
                       onClick={() => {
                         setShowRenameModal(true);
@@ -843,7 +843,7 @@ export default function EditorPage(props) {
                             title="When enabled, the preview uses uncommitted code from all opened files"
                           >
                             <i className="bi bi-asterisk" /> Multi-file preview
-                            ({uncommittedPreviews ? 'ON' : 'OFF'})
+                            ({uncommittedPreviews ? "ON" : "OFF"})
                           </button>
                         </li>
                       </ul>
@@ -851,10 +851,10 @@ export default function EditorPage(props) {
                   </Buttons>
                 </div>
               </div>
-              <div className={`${tab === Tab.Props ? '' : 'visually-hidden'}`}>
+              <div className={`${tab === Tab.Props ? "" : "visually-hidden"}`}>
                 <div
                   className="d-flex flex-column overflow-hidden"
-                  style={{ height: '80vh' }}
+                  style={{ height: "80vh" }}
                 >
                   <div
                     className="mb-2 flex-grow-1 border"
@@ -872,14 +872,14 @@ export default function EditorPage(props) {
                   <div className=" mb-3">^^ Props for debugging (in JSON)</div>
                   {propsError && (
                     <pre className="alert alert-danger">{propsError}</pre>
-                  )}{' '}
+                  )}{" "}
                 </div>
               </div>
               <div
                 className={`${
                   tab === Tab.Metadata && props.widgets.widgetMetadataEditor
-                    ? ''
-                    : 'visually-hidden'
+                    ? ""
+                    : "visually-hidden"
                 }`}
               >
                 <div className="mb-3">
@@ -903,7 +903,7 @@ export default function EditorPage(props) {
                 tab === Tab.Widget ||
                 (layout === Layout.Split && tab !== Tab.Metadata)
                   ? layoutClass
-                  : 'visually-hidden'
+                  : "visually-hidden"
               }`}
             >
               <div className="container">
@@ -925,7 +925,7 @@ export default function EditorPage(props) {
             </div>
             <div
               className={`${
-                tab === Tab.Metadata ? layoutClass : 'visually-hidden'
+                tab === Tab.Metadata ? layoutClass : "visually-hidden"
               }`}
             >
               <div className="container">


### PR DESCRIPTION
Closes: https://github.com/near/near-discovery/issues/852 

Here are some test cases for anyone interested in testing the desired behavior.

1. From the near.social hamburger menu click fork 

2. The IDE should open with the forked component code in focus, there should be a default tab visible.

3. When switching between tabs the editor should display the code associated with the selected tab

4. When "saving"(equivalenet to near.org publish) the user should be prompted with a "Saving Data" modal. Ensure that the metadata for the fork_of property is there if the current component is in fact a fork and not there if the component is not a fork.

5. Ensure that if there are multiple components in the editor that switching between the tabs results in the component data in the active tab of the editor to be displayed in the "Saving Data" modal.

6. When renaming a forked component the metadata is still properly attributed to the component when publishing

