### PR TITLE
fix: open graph & twitter meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,20 +11,25 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json" />
-    <meta
-      name="description"
-      content="Decentralized Customizable Social Network on NEAR Protocol"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@NearSocial_" />
-    <meta property="og:image" content="https://near.social/logo.png" />
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="Near Social" />
-    <meta
-      property="og:description"
-      content="Decentralized Customizable Social Network on NEAR Protocol"
-    />
+    <!-- HTML Meta Tags -->
     <title>Near Social</title>
+    <meta name="description" content="Decentralized Customizable Social Network on NEAR Protocol">
+
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:url" content="https://near.social/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Near Social">
+    <meta property="og:description" content="Decentralized Customizable Social Network on NEAR Protocol">
+    <meta property="og:image" content="https://near.social/logo.png">
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="twitter:domain" content="near.social">
+    <meta property="twitter:url" content="https://near.social/">
+    <meta name="twitter:title" content="Near Social">
+    <meta name="twitter:description" content="Decentralized Customizable Social Network on NEAR Protocol">
+    <meta name="twitter:image" content="https://near.social/logo.png">
+    <meta name="twitter:site" content="@NearSocial_" />
   </head>
   <body>
     <noscript style="white-space: pre; font-family: monospace">


### PR DESCRIPTION
Fix Open Graph & Twitter meta tags to support Twitter card and OG link previews.

Current OG / Twitter card previews: [near.social OG previews](https://opengraph.dev/panel?url=https%3A%2F%2Fnear.social)
<img width="400" alt="image" src="https://github.com/NearSocial/viewer/assets/12901349/3f2cc1a8-fb75-4ccc-9ac3-821b3f36c88c">


Example gateway with updated OG / Twitter tags: [bos.potlock.org OG previews](https://opengraph.dev/panel?url=https%3A%2F%2Fbos.potlock.org)

<img width="400" alt="image" src="https://github.com/NearSocial/viewer/assets/12901349/7e4a9dc5-cd5d-4bd9-8dea-26f2efd9f4a7">
